### PR TITLE
trackFingerprint([customerId, [callback]])

### DIFF
--- a/ravelin.js
+++ b/ravelin.js
@@ -937,9 +937,11 @@
     /**
      * trackFingerprint sends device information back to Ravelin. Invoke from
      * the checkout page of your payment flow.
+     *
+     * @param {Object} meta Any additional metadata you wish to use to describe the event.
      */
     RavelinJS.prototype.trackFingerprint = function() {
-      this._ravelin(['fingerprint']);
+      this._ravelin(['fingerprint'].concat(Array.prototype.slice.call(arguments, 0)));
     }
 
     /**

--- a/ravelin.js
+++ b/ravelin.js
@@ -938,10 +938,12 @@
      * trackFingerprint sends device information back to Ravelin. Invoke from
      * the checkout page of your payment flow.
      *
-     * @param {Object} meta Any additional metadata you wish to use to describe the event.
+     * @param {String} customerId The customerId to set for this device fingerprint. Optional if setCustomerId called in advance.
+     * @param {Function} callback Optional callback to check the fingerprint has completed. Prefer calling trackFingerprint on page load.
      */
-    RavelinJS.prototype.trackFingerprint = function() {
-      this._ravelin(['fingerprint'].concat(Array.prototype.slice.call(arguments, 0)));
+    RavelinJS.prototype.trackFingerprint = function(customerId) {
+      if (customerId) this.setCustomerId(customerId);
+      this._ravelin(['fingerprint'].concat(Array.prototype.slice.call(arguments, 1)));
     }
 
     /**
@@ -978,7 +980,7 @@
 
     /**
      * Set the tempCustomerId submitted with requests. This is used as a temporary association between device/
-     * session data and a user, and should be followed with a v2/login request to Ravelin as soon as a 
+     * session data and a user, and should be followed with a v2/login request to Ravelin as soon as a
      * customerId is available
      *
      * @param {String} customerId


### PR DESCRIPTION
The usual call to `trackFingerprint` on page load is now preferred to be `trackFingerprint(customerId)` while fingerprinting still requires the customerId up front. A callback can be added as a second parameter. `trackFingerprint(undefined, myCallback)` will trigger the fingerprinting with callback, without overriding any previously set customerId. The argument-less `trackFingerprint()` invocation still requires that `setCustomerId` has been called in advance.