### PR TITLE
circle-wait

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     docker:
       # specify the version you desire here
       - image: circleci/node:8.11
-      
+
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images
       # documented at https://circleci.com/docs/2.0/circleci-images/
@@ -28,11 +28,16 @@ jobs:
           paths:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
-        
+
       # run tests!
       - run:
           name: "Unit Tests: npm test"
           command: npm test
+
+      - run:
+          name: "Await crossbrowsertesting.com build slot"
+          command: node_modules/.bin/circle-wait
+
       - run:
           name: "Encryption E2E tests: npm run test-crossbrowser-e2e"
           command: |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ravelinjs",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -7816,6 +7816,15 @@
         "safe-buffer": "5.1.1"
       }
     },
+    "circle-wait": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/circle-wait/-/circle-wait-1.0.2.tgz",
+      "integrity": "sha512-KtWHtEDXJ0iWoazszquMYOw9nCreE+Yq61pWa9gUYbio3nFjLMIwcnYOoI7KspSEygGgzvbhkQKcNomR9a3Rrw==",
+      "dev": true,
+      "requires": {
+        "node-fetch": "2.2.0"
+      }
+    },
     "circular-json": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.5.4.tgz",
@@ -11533,6 +11542,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
+      "dev": true
+    },
+    "node-fetch": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.2.0.tgz",
+      "integrity": "sha512-OayFWziIxiHY8bCUyLX6sTpDH8Jsbp4FfYd1j1f7vZyfgkcOnAyM4oQR16f8a0s7Gl/viMGRey8eScYk4V4EZA==",
       "dev": true
     },
     "node-libs-browser": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "appium-doctor": "^1.4.3",
     "cbt_tunnels": "^0.9.4",
     "chai": "^4.1.2",
+    "circle-wait": "^1.0.2",
     "request": "^2.85.0",
     "uglify-js": "^2.8.29",
     "wait-port": "^0.2.2",


### PR DESCRIPTION
Only run one Circle CI job at a time, so that we don't exceed crossbrowsertesting.com's parallelism constraints, and fail builds _all the time_ on account of it.