### PR TITLE
Extend e2e test and test pages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
           name: "Encryption E2E tests: npm run test-crossbrowser-e2e"
           command: |
             if [ ! "${E2E_RSA_KEY:-}" ]; then echo E2E_RSA_KEY not set. Skipping... && exit 0; fi
-            env E2E_CIPHERTEXT_FILE=~/repo/cipher.txt npm run test-crossbrowser-e2e
+            npm run test-crossbrowser-e2e
 
       - run:
           name: "Cross-browser integration tests: npm run test-crossbrowser"
@@ -56,3 +56,7 @@ jobs:
           path: ~/repo/test/shots
       - store_artifacts:
           path: ~/repo/cipher.txt
+      - store_artifacts:
+          path: ~/repo/deviceid.txt
+      - store_artifacts:
+          path: ~/repo/sessionid.txt

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test-appium": "npm run minify && wdio ./test/appium.conf.js",
     "test-crossbrowser": "npm run minify && wdio ./test/crossbrowser.conf.js",
     "test-crossbrowser-e2e": "wdio ./test/crossbrowser-e2e.conf.js",
-    "live-crossbrowser": "sh -u -c 'cbt_tunnels --username $CROSSBROWSERTESTING_USER --authkey $CROSSBROWSERTESTING_KEY --dir ./test/'"
+    "live-crossbrowser": "sh -u -c 'cbt_tunnels --username $CROSSBROWSERTESTING_USER --authkey $CROSSBROWSERTESTING_KEY --dir ./test/'",
+    "go-serve": "goexec 'http.ListenAndServe(\":8088\", http.FileServer(http.Dir(\".\")))'"
   },
   "repository": {
     "type": "git",

--- a/test/base.conf.js
+++ b/test/base.conf.js
@@ -133,7 +133,7 @@ exports.config = {
     // See the full list at http://mochajs.org/
     mochaOpts: {
         ui: 'bdd',
-        timeout: 30000,
+        timeout: 60000,
     },
 
     // Test reporter for stdout.

--- a/test/crossbrowser.conf.js
+++ b/test/crossbrowser.conf.js
@@ -29,13 +29,13 @@ exports.config = Object.assign(base, {
             version: 'latest',
             platform: 'Windows 10',
         },
-        // {
-        //     build: 'ravelinjs 1.0',
-        //     name: 'osx chromeLatest',
-        //     browserName: 'Chrome',
-        //     version: 'latest',
-        //     platform: 'Mac OSX 10.12',
-        // },
+        {
+            build: 'ravelinjs 1.0',
+            name: 'osx chromeLatest',
+            browserName: 'Chrome',
+            version: 'latest',
+            platform: 'Mac OSX 10.12',
+        },
         {
             build: 'ravelinjs 1.0',
             name: 'win8 chrome18',
@@ -44,27 +44,20 @@ exports.config = Object.assign(base, {
             platform: 'Windows 8',
         },
         // Safari.
-        // {
-        //     build: 'ravelinjs 1.0',
-        //     name: 'osx safari11',
-        //     browserName: 'Safari',
-        //     version: '11',
-        //     platform: 'Mac OSX 10.13',
-        // },
-        // {
-        //     build: 'ravelinjs 1.0',
-        //     name: 'osx safari10',
-        //     browserName: 'Safari',
-        //     version: '10',
-        //     platform: 'Mac OSX 10.12',
-        // },
-        // {
-        //     build: 'ravelinjs 1.0',
-        //     name: 'osx safari6',
-        //     browserName: 'Safari',
-        //     version: '6.2',
-        //     platform: 'Mac OSX 10.8',
-        // },
+        {
+            build: 'ravelinjs 1.0',
+            name: 'osx safari11',
+            browserName: 'Safari',
+            version: '11',
+            platform: 'Mac OSX 10.13',
+        },
+        {
+            build: 'ravelinjs 1.0',
+            name: 'osx safari10',
+            browserName: 'Safari',
+            version: '10',
+            platform: 'Mac OSX 10.12',
+        },
         // Firefox.
         {
             build: 'ravelinjs 1.0',

--- a/test/pages/amd-min/common.js
+++ b/test/pages/amd-min/common.js
@@ -1,0 +1,1 @@
+../common.js

--- a/test/pages/amd/common.js
+++ b/test/pages/amd/common.js
@@ -1,0 +1,1 @@
+../common.js

--- a/test/pages/amd/index.html
+++ b/test/pages/amd/index.html
@@ -9,11 +9,20 @@
 <body>
     <pre id="useragent"></pre>
     <div style="display:flex; flex-direction:row">
-        <pre style="display:inline-block" id="cookies"><b>Cookies: </b></pre>
+        <span style="display:inline-block">
+            <b>Cookies: </b>
+            <pre style="display:inline-block" id="cookies"></pre>
+        </span>
     </div>
     <div style="display:flex; flex-direction:row">
-        <pre style="display:inline-block" id="deviceId"><b>DeviceId: </b></pre>
-        <pre style="display:inline-block" id="sessionId"><b>SessionId: </b></pre>
+        <span style="display:inline-block">
+            <b>DeviceId: </b>
+            <pre style="display:inline-block" id="deviceId"></pre>
+        </span>
+        <span style="display:inline-block">
+            <b>SessionId: </b>
+            <pre style="display:inline-block" id="sessionId"></pre>
+        </span>
     </div>
 
     <div id="container">

--- a/test/pages/amd/index.html
+++ b/test/pages/amd/index.html
@@ -7,56 +7,97 @@
     <link rel="stylesheet" href="../style.css" />
 </head>
 <body>
-    <h1>Test</h1>
-
-    <h2>User Agent</h2>
     <pre id="useragent"></pre>
+    <div style="display:flex; flex-direction:row">
+        <pre style="display:inline-block" id="cookies"><b>Cookies: </b></pre>
+    </div>
+    <div style="display:flex; flex-direction:row">
+        <pre style="display:inline-block" id="deviceId"><b>DeviceId: </b></pre>
+        <pre style="display:inline-block" id="sessionId"><b>SessionId: </b></pre>
+    </div>
 
-    <h2>Payment Information</h2>
-    <form method="get" id="form">
-        Name on Card: <input type="text" id="name" />
-        Card Number: <input type="text" id="number" />
-        Month: <select id="month">
-            <option selected value="1">January</option>
-            <option value="2">February</option>
-            <option value="3">March</option>
-            <option value="4">April</option>
-            <option value="5">May</option>
-            <option value="6">June</option>
-            <option value="7">July</option>
-            <option value="8">August</option>
-            <option value="9">September</option>
-            <option value="10">October</option>
-            <option value="11">November</option>
-            <option value="12">December</option>
-        </select><br />
-        Year: <input type="number" id="year" />
-        <br /> <input type="submit" id="update" />
-    </form>
+    <div id="container">
+        <div class="row">
+            <div class="block">
+                RSA Public Key: <textarea id="rsaKey" rows="5"></textarea>
+                <br/>
+                <button id="setRSAKey"/> Set </button>
+            </div>
 
-    <h2>Output</h2>
-    <pre id="output"></pre>
-    <h2>Output Error</h2>
-    <pre id="output-error"></pre>
+            <div class="block">
+                Publishable Token: <input id="pubToken" type="text" value="">
+                <br/><button id="setPublicAPIKey"> Set </button>
+            </div>
 
-    <script src="../common.js"></script>
+            <div class="block">
+                <span>CustomerId: </span>
+                <div class="row">
+                    <input id="customerId" type="text">
+                    <button id="setCustomerId"> Set </button>
+                </div>
+                <span>TempCustomerId: </span>
+                <div class="row">
+                    <input id="tempCustomerId" type="text">
+                    <button id="setTempCustomerId"> Set </button>
+                </div>
+                <span>OrderId: </span>
+                <div class="row">
+                    <input id="orderId" type="text">
+                    <button id="setOrderId"> Set </button>
+                </div>
+            </div>
+
+            <div class="block column">
+                <button id="trackFingerprint" style="width:100px;">Fingerprint</button>
+                <button id="track" style="width:100px;">Track</button>
+                <button id="trackPage" style="width:100px;">Track Page</button>
+                <button id="trackLogin" style="width:100px;">Track Login</button>
+                <button id="trackLogout" style="width:100px;">Track Logout</button>
+            </div>
+        </div>
+    </div>
+    <div class="row">
+        <div class="column">
+            <h2>Encryption</h2>
+            <div class="block">
+                Name on Card: <input type="text" id="name" />
+                Card Number: <input type="text" id="number" />
+                Month: <select id="month">
+                    <option selected value="1">January</option>
+                    <option value="2">February</option>
+                    <option value="3">March</option>
+                    <option value="4">April</option>
+                    <option value="5">May</option>
+                    <option value="6">June</option>
+                    <option value="7">July</option>
+                    <option value="8">August</option>
+                    <option value="9">September</option>
+                    <option value="10">October</option>
+                    <option value="11">November</option>
+                    <option value="12">December</option>
+                </select><br/>
+                Year: <input type="number" id="year" />
+
+                <br/> <button id="encrypt" > Encrypt </button>
+            </div>
+            <h2>Output</h2>
+            <pre id="encryptionOutput"></pre>
+            <h2>Output Error</h2>
+            <pre id="encryptionOutputError"></pre>
+        </div>
+        <div class="column">
+            <h2>Fingerprint Error</h2>
+            <pre id="fingerprintError"></pre>
+        </div>
+        <div class="column">
+            <h2>Tracking Error</h2>
+            <pre id="trackingError"></pre>
+        </div>
+    </div>
+
     <script src="require.js"></script>
     <script>
-        require(['ravelin'], function(ravelin) {
-            ravelin.setRSAKey('10001|BB2D2D2FD3812FEBECF8955843228A0E1952342583DFC02B8393475C414E16FDCBE8753BD63C164104785D8A67E344D495B5C0C622CE8D643F3191BC6BE0D3050F391F77E1D7E1B8F69DA34B308477E31F775CCC44158E33FD7DDD51AC87DD33AD80B9B1BF850CEC79A189F011C0689C36C0C91BF6DB9CD65BB7399710E32D9876C00DD44103E54A64A44BF427E1BA4F48DA7AF3D623DBCCF282ED8D4CCAE31B921A9BE92F9E8D7B5C50FBD89D828539CAE3E3493D4F6D7ADA19A876D9DF3801B5C3CFFA6A3C72A246150F307D789BAD6E2408DA5EF05EE805E11C133FFEDFA57CD1C35E49106ADDAC43C51995B9C318066C9ACB4042D8A534370D79F1BAD601');
-            document.getElementById('form').onsubmit = function() {
-                var month = document.getElementById('month');
-                output(function() {
-                    return ravelin.encrypt({
-                        nameOnCard: document.getElementById('name').value,
-                        pan: document.getElementById('number').value,
-                        month: month.options[month.selectedIndex].value,
-                        year: document.getElementById('year').value,
-                    });
-                });
-                return false;
-            };
-        })
+        require(['common', 'ravelin'], function(TestPageSetup, ravelinjs) { new TestPageSetup(ravelinjs); });
     </script>
 </body>
 </html>

--- a/test/pages/common.js
+++ b/test/pages/common.js
@@ -58,11 +58,10 @@
 
   function writeCookiesAndIds() {
     var cookiesElem = document.getElementById('cookies');
-    if (cookiesElem.innerHTML != "") {
-      return;
+    if (cookiesElem.innerHTML == '') {
+      cookiesElem.appendChild(document.createTextNode(document.cookie));
     }
 
-    cookiesElem.appendChild(document.createTextNode(document.cookie));
     var cookies = document.cookie.split('; ');
     for (var i = cookies.length-1; i >= 0; i--) {
       var x = cookies[i].split('=');
@@ -70,9 +69,15 @@
       var cookieVal = x[1];
 
       if (cookieName === 'ravelinDeviceId') {
-        document.getElementById('deviceId').appendChild(document.createTextNode(cookieVal));
-      } else if (cookieName === 'ravelinSessionId'){
-        document.getElementById('sessionId').appendChild(document.createTextNode(cookieVal));
+        var devIdElem = document.getElementById('deviceId');
+        if (devIdElem.innerHTML == '') {
+          devIdElem.appendChild(document.createTextNode(cookieVal));
+        }
+      } else if (cookieName === 'ravelinSessionId') {
+        var sesIdElem = document.getElementById('sessionId');
+        if (sesIdElem.innerHTML == '') {
+          sesIdElem.appendChild(document.createTextNode(cookieVal));
+        }
       }
     };
   }

--- a/test/pages/common.js
+++ b/test/pages/common.js
@@ -73,7 +73,7 @@
         if (devIdElem.innerHTML == '') {
           devIdElem.appendChild(document.createTextNode(cookieVal));
         }
-      } else if (cookieName === 'ravelinSessionId') {
+      } else if (cookieName === 'ravelinSessionUuid') {
         var sesIdElem = document.getElementById('sessionId');
         if (sesIdElem.innerHTML == '') {
           sesIdElem.appendChild(document.createTextNode(cookieVal));

--- a/test/pages/common.js
+++ b/test/pages/common.js
@@ -1,20 +1,146 @@
-(function (root, factory) {
+(function(root, factory) {
   if (typeof define === 'function' && define.amd) {
     define([], factory);
   } else if (typeof module === 'object' && module.exports) {
     module.exports = factory();
   } else {
-    root.output = factory();
+    root.TestPageSetup = factory();
   }
-}(typeof self !== 'undefined' ? self : this, function () {
-  document.getElementById("useragent").appendChild(document.createTextNode(navigator.userAgent));
-  return function output(action) {
-    // Reset the output.
-    var stdout = document.getElementById('output');
-    var stderr = document.getElementById('output-error');
+}(typeof self !== 'undefined' ? self : this, function() {
+
+  // This is the constructor for a helper obj that standardises all the setup code across amd/script/webpack pages.
+  // Instantiating this with the ravelinjs instance will instantiate cookies/user agent/ids, register all the
+  // onclick listeners, set the public api key etc.
+  function TestPageSetup(ravelinjsInstance) {
+    wireUpSetterFuncs(ravelinjsInstance);
+    wireUpTrackingFuncs(ravelinjsInstance);
+    wireUpEncryptionFunc(ravelinjsInstance);
+
+    // The default instantiation for our test files is associated to the CID 'ravelinjs'.
+    // Both the RSA key and the public API token are hard coded into this repo (and thus visibile in github).
+    // This CID has the private token disabled, and is isolated so that there is no possibility for mischief
+    // with these values. The e2e tests will override the RSA key and public API token for their tests.
+    setHardCodedRavelinJSTestPubToken();
+    setHardCodedRSAKey();
+
+    var custId = 'cust-' + generateRandomString();
+    setCustomerId(custId);
+
+    setUserAgent();
+    writeCookiesAndIds();
+  }
+
+  // Init ravelinjs and the HTML page with a hardcoded public API key associated to the ravelinjs CID
+  function setHardCodedRavelinJSTestPubToken() {
+    document.getElementById('pubToken').value = 'publishable_key_live_rbe3yd3bpGaCDA9qRxKW9NuuVB1yulNR';
+    document.getElementById('setPublicAPIKey').click();
+  }
+
+  // Init ravelinjs and the HTML page with a hardcoded public API key associated to the ravelinjs CID
+  function setHardCodedRSAKey() {
+    var key = '10001|B84498733A4CF477091B6D052129D4B528CB308B30B5567CAAF307608CF2F44D8ADC35191F45BB36A5ACBC191E8EAE6B1F2A80A2EC7F78815179A020246B1D6921EA9CADEE9C16B3FA33EF0183C6F13E3AE35BED0E4A84977B05A32C2C15EA5FEAC6BD594C83C0A226CC1776C26737E9B69E0B183F8F9184ADC44EC5751D1A863BD55E15A148C3B28D649B214890E8D0586AF5E982DB4559156EAA464C712FD7776E8C1C191BA67BA464973F4EB6F8BCEA08FB95EEE09EDAE6F4A8340C7A2833BFE905200488D896A8294A423A59B5058B03F1B82B6CCB6C4746BA297F7BD2D8494B36F02E0EDFF31CDBD73D6FA9BFE958BA58ACEE9CCDC87069C07DB8C6EC63';
+    document.getElementById('rsaKey').value = key;
+    document.getElementById('setRSAKey').click();
+  }
+
+  function setUserAgent() {
+    document.getElementById('useragent').appendChild(document.createTextNode(navigator.userAgent));
+  }
+
+  function generateRandomString() {
+    return Math.random().toString(36).substring(5) + Math.random().toString(36).substring(5);
+  }
+
+  function setCustomerId(custId) {
+    document.getElementById('customerId').value = custId;
+    document.getElementById('setCustomerId').click();
+  }
+
+  function writeCookiesAndIds() {
+    document.getElementById('cookies').appendChild(document.createTextNode(document.cookie));
+    var cookies = document.cookie.split('; ');
+    for (var i = cookies.length-1; i >= 0; i--) {
+      var x = cookies[i].split('=');
+      var cookieName = x[0];
+      var cookieVal = x[1];
+
+      if (cookieName === 'ravelinDeviceId') {
+        document.getElementById('deviceId').appendChild(document.createTextNode(cookieVal));
+      } else if (cookieName === 'ravelinSessionId'){
+        document.getElementById('sessionId').appendChild(document.createTextNode(cookieVal));
+      }
+    };
+  }
+
+  // Wire up 'setter' buttons that set keys, tokens ids etc to associated rjs buttons
+  function wireUpSetterFuncs(rjsInstance) {
+    var setRSAKey = function() { rjsInstance.setRSAKey(document.getElementById('rsaKey').value); };
+    var setPublicAPIKey = function() { rjsInstance.setPublicAPIKey(document.getElementById('pubToken').value); };
+    var setCustomerId = function() {rjsInstance.setCustomerId(document.getElementById('customerId').value); };
+    var setTempCustomerId = function() {rjsInstance.setTempCustomerId(document.getElementById('tempCustomerId').value); };
+    var setOrderId = function() { rjsInstance.setOrderId(document.getElementById('orderId').value); };
+
+    document.getElementById('setRSAKey').onclick = setRSAKey;
+    document.getElementById('setPublicAPIKey').onclick = setPublicAPIKey;
+    document.getElementById('setCustomerId').onclick = setCustomerId;
+    document.getElementById('setTempCustomerId').onclick = setTempCustomerId;
+    document.getElementById('setOrderId').onclick = setOrderId;
+  }
+
+  function wireUpTrackingFuncs(rjsInstance) {
+    var trackFingerprint = function() { rjsInstance.trackFingerprint(null, writeFingerprintError); };
+    var trackPage = trackWithErrHandlingCallback(rjsInstance, rjsInstance.trackPage, [null]);
+    var track = trackWithErrHandlingCallback(rjsInstance, rjsInstance.track, ['RANDOM', { rand: generateRandomString() }]);
+
+    var trackLogout = trackWithErrHandlingCallback(rjsInstance, rjsInstance.trackLogout, [null]);
+
+    document.getElementById('trackFingerprint').onclick = trackFingerprint;
+    document.getElementById('track').onclick = track;
+    document.getElementById('trackPage').onclick = trackPage;
+    document.getElementById('trackLogout').onclick = trackLogout;
+
+    // We don't have trackLogin yet
+    // document.getElementById('trackLogin').onclick = trackLogin;
+    // var trackLogin = trackWithErrHandlingCallback(rjsInstance, rjsInstance.trackLogin, [null, null]);
+  }
+
+  function wireUpEncryptionFunc(rjsInstance) {
+    document.getElementById('encrypt').onclick = function() {
+      var month = document.getElementById('month');
+      writeEncryptionOutput(function() {
+        return rjsInstance.encrypt({
+          nameOnCard: document.getElementById('name').value,
+          pan: document.getElementById('number').value,
+          month: month.options[month.selectedIndex].value,
+          year: document.getElementById('year').value,
+        });
+      });
+    };
+  }
+
+  function writeFingerprintError(err) {
+    document.getElementById('fingerprintError').innerText = err instanceof Error ? err.message : '';
+  }
+
+  // Create a wrapper func that calls a given session-tracking function, along with the provided
+  // params, but also includes a callback that writes any received errors back to the page.
+  // This is useful for asserting that our tracking funcs aren't erroring.
+  function trackWithErrHandlingCallback(rjsInstance, trackFunc, params) {
+    params = params ? params : [];
+    params.push(function(err) {
+      document.getElementById('trackingError').innerText = err ? err.message : '';
+    });
+
+    return function () { trackFunc.apply(rjsInstance, params); };
+  }
+
+  function writeEncryptionOutput(action) {
+    // Reset the output
+    var stdout = document.getElementById('encryptionOutput');
+    var stderr = document.getElementById('encryptionOutputError');
     stdout.innerHTML = stderr.innerHTML = '';
 
-    // Collect the output.
+    // Collect the output
     var output, error;
     try {
       output = action();
@@ -22,8 +148,10 @@
       error = e;
     }
 
-    // Show the output.
+    // Show the output
     if (output) stdout.appendChild(document.createTextNode(output));
     if (error) stderr.appendChild(document.createTextNode(error));
   }
+
+  return TestPageSetup;
 }));

--- a/test/pages/common.js
+++ b/test/pages/common.js
@@ -57,7 +57,12 @@
   }
 
   function writeCookiesAndIds() {
-    document.getElementById('cookies').appendChild(document.createTextNode(document.cookie));
+    var cookiesElem = document.getElementById('cookies');
+    if (cookiesElem.innerHTML != "") {
+      return;
+    }
+
+    cookiesElem.appendChild(document.createTextNode(document.cookie));
     var cookies = document.cookie.split('; ');
     for (var i = cookies.length-1; i >= 0; i--) {
       var x = cookies[i].split('=');
@@ -119,6 +124,7 @@
   }
 
   function writeFingerprintError(err) {
+    writeCookiesAndIds(); // Temporary measure as we haven't yet ported deviceId setting into ravelinjs
     document.getElementById('fingerprintError').innerText = err instanceof Error ? err.message : '';
   }
 

--- a/test/pages/scripttag/index.html
+++ b/test/pages/scripttag/index.html
@@ -7,73 +7,106 @@
     <link rel="stylesheet" href="../style.css" />
 </head>
 <body>
-    <h1><code>ravelinjs</code> Demo</h1>
 
-    <h2>User Agent</h2>
     <pre id="useragent"></pre>
+    <div style="display:flex; flex-direction:row">
+        <span style="display:inline-block">
+            <b>Cookies: </b>
+            <pre style="display:inline-block" id="cookies"></pre>
+        </span>
+    </div>
+    <div style="display:flex; flex-direction:row">
+        <span style="display:inline-block">
+            <b>DeviceId: </b>
+            <pre style="display:inline-block" id="deviceId"></pre>
+        </span>
+        <span style="display:inline-block">
+            <b>SessionId: </b>
+            <pre style="display:inline-block" id="sessionId"></pre>
+        </span>
+    </div>
 
-    <h2>Encryption Public Key</h2>
-    <form id="key-form">
-        RSA Public Key: <textarea id="rsa-key" rows="5">10001|BB2D2D2FD3812FEBECF8955843228A0E1952342583DFC02B8393475C414E16FDCBE8753BD63C164104785D8A67E344D495B5C0C622CE8D643F3191BC6BE0D3050F391F77E1D7E1B8F69DA34B308477E31F775CCC44158E33FD7DDD51AC87DD33AD80B9B1BF850CEC79A189F011C0689C36C0C91BF6DB9CD65BB7399710E32D9876C00DD44103E54A64A44BF427E1BA4F48DA7AF3D623DBCCF282ED8D4CCAE31B921A9BE92F9E8D7B5C50FBD89D828539CAE3E3493D4F6D7ADA19A876D9DF3801B5C3CFFA6A3C72A246150F307D789BAD6E2408DA5EF05EE805E11C133FFEDFA57CD1C35E49106ADDAC43C51995B9C318066C9ACB4042D8A534370D79F1BAD601</textarea>
-        <br /><input type="submit" value="Set" /> <input type="reset" />
-    </form>
+    <div id="container">
+        <div class="row">
+            <div class="block">
+                RSA Public Key: <textarea id="rsaKey" rows="5"></textarea>
+                <br/>
+                <button id="setRSAKey"/> Set </button>
+            </div>
 
-    <h2>Payment Information</h2>
-    <form method="get" id="form">
-        Name on Card: <input type="text" id="name" />
-        Card Number: <input type="text" id="number" />
-        Month: <select id="month">
-            <option selected value="1">January</option>
-            <option value="2">February</option>
-            <option value="3">March</option>
-            <option value="4">April</option>
-            <option value="5">May</option>
-            <option value="6">June</option>
-            <option value="7">July</option>
-            <option value="8">August</option>
-            <option value="9">September</option>
-            <option value="10">October</option>
-            <option value="11">November</option>
-            <option value="12">December</option>
-        </select><br />
-        Year: <input type="number" id="year" />
+            <div class="block">
+                Publishable Token: <input id="pubToken" type="text" value="">
+                <br/><button id="setPublicAPIKey"> Set </button>
+            </div>
 
-        <br /> <input type="submit" id="update" value="Encrypt" />
-    </form>
+            <div class="block">
+                <span>CustomerId: </span>
+                <div class="row">
+                    <input id="customerId" type="text">
+                    <button id="setCustomerId"> Set </button>
+                </div>
+                <span>TempCustomerId: </span>
+                <div class="row">
+                    <input id="tempCustomerId" type="text">
+                    <button id="setTempCustomerId"> Set </button>
+                </div>
+                <span>OrderId: </span>
+                <div class="row">
+                    <input id="orderId" type="text">
+                    <button id="setOrderId"> Set </button>
+                </div>
+            </div>
 
-    <h2>Output</h2>
-    <pre id="output"></pre>
-    <h2>Output Error</h2>
-    <pre id="output-error"></pre>
+            <div class="block column">
+                <button id="trackFingerprint" style="width:100px;">Fingerprint</button>
+                <button id="track" style="width:100px;">Track</button>
+                <button id="trackPage" style="width:100px;">Track Page</button>
+                <button id="trackLogin" style="width:100px;">Track Login</button>
+                <button id="trackLogout" style="width:100px;">Track Logout</button>
+            </div>
+        </div>
+    </div>
+    <div class="row">
+        <div class="column">
+            <h2>Encryption</h2>
+            <div class="block">
+                Name on Card: <input type="text" id="name" />
+                Card Number: <input type="text" id="number" />
+                Month: <select id="month">
+                    <option selected value="1">January</option>
+                    <option value="2">February</option>
+                    <option value="3">March</option>
+                    <option value="4">April</option>
+                    <option value="5">May</option>
+                    <option value="6">June</option>
+                    <option value="7">July</option>
+                    <option value="8">August</option>
+                    <option value="9">September</option>
+                    <option value="10">October</option>
+                    <option value="11">November</option>
+                    <option value="12">December</option>
+                </select><br/>
+                Year: <input type="number" id="year" />
+
+                <br/> <button id="encrypt" > Encrypt </button>
+            </div>
+            <h2>Output</h2>
+            <pre id="encryptionOutput"></pre>
+            <h2>Output Error</h2>
+            <pre id="encryptionOutputError"></pre>
+        </div>
+        <div class="column">
+            <h2>Fingerprint Error</h2>
+            <pre id="fingerprintError"></pre>
+        </div>
+        <div class="column">
+            <h2>Tracking Error</h2>
+            <pre id="trackingError"></pre>
+        </div>
+    </div>
 
     <script src="../common.js"></script>
     <script src="./ravelin.js"></script>
-    <script>
-        document.getElementById('key-form').onsubmit = function() {
-            setRSAKey();
-            return false;
-        };
-
-        function setRSAKey() {
-            output(function() {
-                ravelinjs.setRSAKey(document.getElementById('rsa-key').value);
-                return 'Key set // ' + (new Date);
-            });
-        }
-        setRSAKey();
-
-        document.getElementById('form').onsubmit = function() {
-            var month = document.getElementById('month');
-            output(function() {
-                return ravelinjs.encrypt({
-                    nameOnCard: document.getElementById('name').value,
-                    pan: document.getElementById('number').value,
-                    month: month.options[month.selectedIndex].value,
-                    year: document.getElementById('year').value,
-                });
-            });
-            return false;
-        };
-    </script>
+    <script>new TestPageSetup(ravelinjs);</script>
 </body>
 </html>

--- a/test/pages/style.css
+++ b/test/pages/style.css
@@ -5,33 +5,65 @@ body {
 pre {
     background-color: #EEE;
     margin-left: 20px;
-    padding: 10px;
-
+    padding: 5px;
     font-family: 'Courier New', Courier, monospace;
     white-space: pre-wrap;
     word-break: break-word;
+    margin: 0.5em;
 }
 #output-error {
     background-color: #ECC;
 }
 
-form {
+form, .block {
     margin-left: 20px;
     border: 1px solid black;
     padding: 20px;
     max-width: 300px;
     line-height: 2em;
+    margin-bottom: 25px;
 }
+
 input {
     width: 100%;
 }
+
 input[type=submit], input[type=reset] {
     width: auto;
 }
+
 textarea {
     width: 100%;
     font-family: 'Courier New', Courier, monospace;
 }
+
+button {
+    width: 60px;
+    max-width: 100px;
+    max-height: 100px;
+    height: 30px;
+}
+
 #year {
     width: 50%;
+}
+
+#container {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-evenly;
+}
+
+.row {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-around;
+    width: 100%;
+}
+
+.column {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-around;
+    max-width: 33%;
 }

--- a/test/pages/webpack/index.html
+++ b/test/pages/webpack/index.html
@@ -6,37 +6,93 @@
     <link rel="stylesheet" href="../style.css" />
 </head>
 <body>
-    <h1>Test</h1>
-
-    <h2>User Agent</h2>
     <pre id="useragent"></pre>
+    <div style="display:flex; flex-direction:row">
+        <pre style="display:inline-block" id="cookies"><b>Cookies: </b></pre>
+    </div>
+    <div style="display:flex; flex-direction:row">
+        <pre style="display:inline-block" id="deviceId"><b>DeviceId: </b></pre>
+        <pre style="display:inline-block" id="sessionId"><b>SessionId: </b></pre>
+    </div>
 
-    <h2>Payment Information</h2>
-    <form method="get" id="form">
-        Name on Card: <input type="text" id="name" />
-        Card Number: <input type="text" id="number" />
-        Month: <select id="month">
-            <option selected value="1">January</option>
-            <option value="2">February</option>
-            <option value="3">March</option>
-            <option value="4">April</option>
-            <option value="5">May</option>
-            <option value="6">June</option>
-            <option value="7">July</option>
-            <option value="8">August</option>
-            <option value="9">September</option>
-            <option value="10">October</option>
-            <option value="11">November</option>
-            <option value="12">December</option>
-        </select><br />
-        Year: <input type="number" id="year" />
-        <br /> <input type="submit" id="update" />
-    </form>
+    <div id="container">
+        <div class="row">
+            <div class="block">
+                RSA Public Key: <textarea id="rsaKey" rows="5"></textarea>
+                <br/>
+                <button id="setRSAKey"/> Set </button>
+            </div>
 
-    <h2>Output</h2>
-    <pre id="output"></pre>
-    <h2>Output Error</h2>
-    <pre id="output-error"></pre>
+            <div class="block">
+                Publishable Token: <input id="pubToken" type="text" value="">
+                <br/><button id="setPublicAPIKey"> Set </button>
+            </div>
+
+            <div class="block">
+                <span>CustomerId: </span>
+                <div class="row">
+                    <input id="customerId" type="text">
+                    <button id="setCustomerId"> Set </button>
+                </div>
+                <span>TempCustomerId: </span>
+                <div class="row">
+                    <input id="tempCustomerId" type="text">
+                    <button id="setTempCustomerId"> Set </button>
+                </div>
+                <span>OrderId: </span>
+                <div class="row">
+                    <input id="orderId" type="text">
+                    <button id="setOrderId"> Set </button>
+                </div>
+            </div>
+
+            <div class="block column">
+                <button id="trackFingerprint" style="width:100px;">Fingerprint</button>
+                <button id="track" style="width:100px;">Track</button>
+                <button id="trackPage" style="width:100px;">Track Page</button>
+                <button id="trackLogin" style="width:100px;">Track Login</button>
+                <button id="trackLogout" style="width:100px;">Track Logout</button>
+            </div>
+        </div>
+    </div>
+    <div class="row">
+        <div class="column">
+            <h2>Encryption</h2>
+            <div class="block">
+                Name on Card: <input type="text" id="name" />
+                Card Number: <input type="text" id="number" />
+                Month: <select id="month">
+                    <option selected value="1">January</option>
+                    <option value="2">February</option>
+                    <option value="3">March</option>
+                    <option value="4">April</option>
+                    <option value="5">May</option>
+                    <option value="6">June</option>
+                    <option value="7">July</option>
+                    <option value="8">August</option>
+                    <option value="9">September</option>
+                    <option value="10">October</option>
+                    <option value="11">November</option>
+                    <option value="12">December</option>
+                </select><br/>
+                Year: <input type="number" id="year" />
+
+                <br/> <button id="encrypt" > Encrypt </button>
+            </div>
+            <h2>Output</h2>
+            <pre id="encryptionOutput"></pre>
+            <h2>Output Error</h2>
+            <pre id="encryptionOutputError"></pre>
+        </div>
+        <div class="column">
+            <h2>Fingerprint Error</h2>
+            <pre id="fingerprintError"></pre>
+        </div>
+        <div class="column">
+            <h2>Tracking Error</h2>
+            <pre id="trackingError"></pre>
+        </div>
+    </div>
 
     <script src="bundle.js"></script>
 </body>

--- a/test/pages/webpack/index.js
+++ b/test/pages/webpack/index.js
@@ -1,16 +1,4 @@
 import ravelin from '../../../ravelin.js';
-import output from '../common.js';
+import TestPageSetup from '../common.js';
 
-ravelin.setRSAKey('10001|BB2D2D2FD3812FEBECF8955843228A0E1952342583DFC02B8393475C414E16FDCBE8753BD63C164104785D8A67E344D495B5C0C622CE8D643F3191BC6BE0D3050F391F77E1D7E1B8F69DA34B308477E31F775CCC44158E33FD7DDD51AC87DD33AD80B9B1BF850CEC79A189F011C0689C36C0C91BF6DB9CD65BB7399710E32D9876C00DD44103E54A64A44BF427E1BA4F48DA7AF3D623DBCCF282ED8D4CCAE31B921A9BE92F9E8D7B5C50FBD89D828539CAE3E3493D4F6D7ADA19A876D9DF3801B5C3CFFA6A3C72A246150F307D789BAD6E2408DA5EF05EE805E11C133FFEDFA57CD1C35E49106ADDAC43C51995B9C318066C9ACB4042D8A534370D79F1BAD601');
-document.getElementById('form').onsubmit = function() {
-    var month = document.getElementById('month');
-    output(function() {
-        return ravelin.encrypt({
-            nameOnCard: document.getElementById('name').value,
-            pan: document.getElementById('number').value,
-            month: month.options[month.selectedIndex].value,
-            year: document.getElementById('year').value,
-        });
-    });
-    return false;
-};
+new TestPageSetup(ravelin);

--- a/test/specs/e2e-test.js
+++ b/test/specs/e2e-test.js
@@ -1,60 +1,157 @@
-describe('ravelinjs returns the encrypted card details', function() {
-    const rsaKey = process.env.E2E_RSA_KEY;
-    const nameOnCard = process.env.E2E_NAME_ON_CARD;
-    const outputFilepath = process.env.E2E_CIPHERTEXT_FILE;
-    console.log('Name on card:', nameOnCard);
-    console.log('Ciphertext destination:', outputFilepath);
-    console.log('RSA Key:', rsaKey);
-    if (!rsaKey.match(/^[^|]+\|[^|]+$/)) throw new Error("Envvar E2E_RSA_KEY must be set and of the form ...|...");
-    if (!nameOnCard) throw new Error("Envvar E2E_NAME_ON_CARD must be set.");
-    if (!outputFilepath) throw new Error("Envvar E2E_CIPHERTEXT_FILE must be set.");
+// e2e tests are triggered from inside the Ravelin 'integration-test-service' microservice.
+// They test that the values generated/submitted from the ravelinjs library behave as expected when sent
+// to the Ravelin API. We achieve this by calling ravelinjs functions, writing their outputs to dedicated
+// text files (persisted as 'Artifacts' to the build in CircleCI) and then making assertions against their
+// values from inside the integration-test-service.
+describe('ravelinjs', function() {
 
-    it('loads the page', function() {
-        browser.url('/pages/scripttag/index.html');
-    });
+  // We have hardcoded the file names of our outputs because they must be individually specified as
+  // 'store_artifacts' commands in circle.yml. These files will be written to the root dir of the repo,
+  // and available at the path 'home/circleci/repo/$.txt' via the API.
+  const ciphertextOutputFile = './cipher.txt';
+  const deviceIdFile = './deviceid.txt';
+  const sessionIdFile = './sessionid.txt';
 
-    it('sets up the RSA key', function() {
-        // Set the key.
-        const demoKeyMsg = browser.getText('#output');
-        browser.setValue('#rsa-key', rsaKey);
-        browser.click('#key-form input[type=submit]');
+  // When the integration test is launched, some env variables are also set, some of which are unique per run.
+  // These must also all be provided in order to complete this test suite. See the RavelinJS integration test
+  // to see how these values are generated and how they are provided to the job.
+  const publicApiToken = process.env.E2E_PUBLIC_API_TOKEN;
+  const rsaKey = process.env.E2E_RSA_KEY;
+  const nameOnCard = process.env.E2E_NAME_ON_CARD;
+  const customerId = process.env.E2E_CUSTOMER_ID;
+  const orderId = process.env.E2E_ORDER_ID;
 
-        // Check there wasn't an error.
-        raise(browser.getText('#output-error'));
+  if (!publicApiToken || !publicApiToken.match(/(publishable_key_live_)([0-z]+)/)) {
+    throw new Error("Envvar E2E_PUBLIC_API_TOKEN must be set and of the form publishable_key_live_XXXXXXXX");
+  }
+  if (!rsaKey || !rsaKey.match(/^[^|]+\|[^|]+$/)) {
+    throw new Error("Envvar E2E_RSA_KEY must be set and of the form ...|...");
+  }
 
-        // Confirm the key has been updated.
-        const output = browser.getText('#output');
-        if (output == demoKeyMsg) {
-            throw new Error('Key wasnt changed from default');
-        } else if (!output.match(/^Key set/)) {
-            throw new Error('Output message doesnt suggest key was set');
-        }
-    });
+  if (!nameOnCard) throw new Error("Envvar E2E_NAME_ON_CARD must be set.");
+  if (!customerId) throw new Error("Envvar E2E_CUSTOMER_ID must be set.");
+  if (!orderId) throw new Error("Envvar E2E_ORDER_ID must be set.");
+
+  console.log('Publishable Token:', publicApiToken);
+  console.log('RSA Key:', rsaKey);
+  console.log('Name on card:', nameOnCard);
+  console.log('CustomerId:', customerId);
+  console.log('OrderId:', orderId);
+
+  it('loads the page', function() {
+    browser.url('/pages/scripttag/index.html');
+
+    browser.pause(1000); // Wait for commonjs init to complete
+
+    browser.setValue('#pubToken', publicApiToken);
+    browser.click('#setPublicAPIKey');
+
+    browser.setValue('#rsaKey', rsaKey);
+    browser.click('#setRSAKey');
+
+    browser.setValue('#customerId', customerId);
+    browser.click('#setCustomerId');
+
+    browser.setValue('#customerId', customerId);
+    browser.click('#setCustomerId');
+
+    browser.setValue('#orderId', orderId);
+    browser.click('#setOrderId');
+  });
+
+  // Our first test populates the card encryption form, saves the ciphertext and submits the paymentMethodCipher
+  // for decryption, verifying that the card details saved against the customer match the encrypted inputs.
+  describe('returns the encrypted card details', function() {
 
     var ciphertext;
 
     it('encrypts the cardholder data', function() {
-        // Encrypt the card data.
-        browser.setValue('#name', nameOnCard);
-        browser.setValue('#number', '4111 1111 1111 1111');
-        browser.selectByValue('#month', '4')
-        browser.setValue('#year', '2019');
-        browser.click('#update');
+      // Encrypt the card data.
+      browser.setValue('#name', nameOnCard);
+      browser.setValue('#number', '4111 1111 1111 1111');
+      browser.selectByValue('#month', '4')
+      browser.setValue('#year', '2019');
+      browser.click('#encrypt');
 
-        // Check there wasn't an error.
-        raise(browser.getText('#output-error'));
+      // Check there wasn't an error.
+      raise(browser.getText('#encryptionOutputError'));
 
-        ciphertext = browser.getText('#output');
-        if (!ciphertext.match(/^\{.+\}$/) || !ciphertext.includes("cardCiphertext")) {
-            throw new Error("Doesn't look like we got a valid ciphertext: " + ciphertext);
-        }
+      ciphertext = browser.getText('#encryptionOutput');
+      if (!ciphertext.match(/^\{.+\}$/) || !ciphertext.includes("cardCiphertext")) {
+        throw new Error("Doesn't look like we got a valid ciphertext: " + ciphertext);
+      }
     });
 
     it('writes the cipher to a local file', function() {
-        require('fs').writeFileSync(outputFilepath, ciphertext || '');
+      require('fs').writeFileSync(ciphertextOutputFile, ciphertext || '');
     });
+  });
+
+  // Our second test submits a device fingerprint to the API under a random customerId. Using that same
+  // customerId, we read out their devices and assert that a device with our ravelinjs deviceId exists.
+  describe('ravelinjs tracks and fingerprints the browser', function() {
+
+    it('fingerprints the device and submits details + deviceId to Ravelin', function() {
+      browser.click('#trackFingerprint');
+
+      browser.pause(1000); // Wait for async request to complete
+
+      var error = browser.getText('#fingerprintError');
+      if (error) throw new Error(error);
+    });
+
+    it('writes the deviceId artifact', function() {
+      require('fs').writeFileSync(deviceIdFile, browser.getText('#deviceId') || '');
+    });
+  });
+
+  // Our final test triggers a track event for the 'vanilla', 'page', 'login' and 'logout' events.
+  // Using the same customerId and orderId, we will verify each of these 4 events are recorded against this
+  // session in Ravelin.
+  describe('ravelinjs tracks session activity', function() {
+
+    it('tracks custom events', function() {
+      browser.click('#track');
+
+      browser.pause(1000); // Wait for async request to complete
+
+      var error = browser.getText('#trackingError');
+      if (error) throw new Error(error);
+    });
+
+    it('tracks page load', function() {
+      browser.click('#trackPage');
+
+      browser.pause(1000); // Wait for async request to complete
+
+      var error = browser.getText('#trackingError');
+      if (error) throw new Error(error);
+    });
+
+    it('tracks login', function() {
+      browser.click('#trackLogin');
+
+      browser.pause(1000); // Wait for async request to complete
+
+      var error = browser.getText('#trackingError');
+      if (error) throw new Error(error);
+    });
+
+    it('tracks logout', function() {
+      browser.click('#trackLogout');
+
+      browser.pause(1000); // Wait for async request to complete
+
+      var error = browser.getText('#trackingError');
+      if (error) throw new Error(error);
+    });
+
+    it('writes the sessionId artifact', function() {
+      require('fs').writeFileSync(sessionIdFile, browser.getText('#sessionId') || '');
+    });
+  });
 });
 
 function raise(err) {
-    if (err) throw new Error(err);
+  if (err) throw new Error(err);
 }

--- a/test/specs/test.js
+++ b/test/specs/test.js
@@ -1,48 +1,94 @@
 describe('ravelinjs', function() {
-    const cap = browser.desiredCapabilities;
+  const cap = browser.desiredCapabilities;
 
-    it('can be used with a script tag', function() {
-        browser.url('/pages/scripttag/index.html');
-        suite(browser);
-    });
+  it('can be used with a script tag', function() {
+    browser.url('/pages/scripttag/index.html');
+    suite(browser);
+  });
 
-    it('can be used minified with a script tag', function() {
-        browser.url('/pages/scripttag-min/index.html');
-        suite(browser);
-    });
+  it('can be used minified with a script tag', function() {
+    browser.url('/pages/scripttag-min/index.html');
+    suite(browser);
+  });
 
-    usuallyIt(!cap.requireJSTestDisabled, 'can be used with requirejs', function() {
-        browser.url('/pages/amd/index.html');
-        suite(browser);
-    });
+  usuallyIt(!cap.requireJSTestDisabled, 'can be used with requirejs', function() {
+    browser.url('/pages/amd/index.html');
+    suite(browser);
+  });
 
-    usuallyIt(!cap.requireJSTestDisabled, 'can be used minified with requirejs', function() {
-        browser.url('/pages/amd-min/index.html');
-        suite(browser);
-    });
+  usuallyIt(!cap.requireJSTestDisabled, 'can be used minified with requirejs', function() {
+    browser.url('/pages/amd-min/index.html');
+    suite(browser);
+  });
 
-    usuallyIt(!cap.webpackTestDisabled, 'can be used with webpack', function() {
-        browser.url('/pages/webpack/index.html');
-        suite(browser);
-    });
+  usuallyIt(!cap.webpackTestDisabled, 'can be used with webpack', function() {
+    browser.url('/pages/webpack/index.html');
+    suite(browser);
+  });
 });
 
 function suite(browser) {
-    // Do the form.
-    browser.setValue('#name', 'John');
-    browser.setValue('#number', '4111 1111 1111 1111');
-    browser.selectByValue('#month', '4')
-    browser.setValue('#year', '2019');
-    browser.click('#update');
+  checkIdsAreSet(browser);
+  checkCardEncryptionWorks(browser);
+  checkFingerprintingDoesNotError(browser);
+  checkTrackingEventsDoNotError(browser);
+}
 
-    // Check there was no error.
-    var error = browser.getText('#output-error');
+function checkIdsAreSet(browser) {
+  // Ensure that deviceId/sessionId are set upon lib instantiation
+  browser.getText('#deviceId').should.not.be.empty;
+  browser.getText('#sessionId').should.not.be.empty;
+  browser.getText('#cookies').should.not.be.empty;
+}
+
+function checkCardEncryptionWorks(browser) {
+  // Fill in the card encryption form
+  browser.setValue('#name', 'John');
+  browser.setValue('#number', '4111 1111 1111 1111');
+  browser.selectByValue('#month', '4')
+  browser.setValue('#year', '2019');
+  browser.click('#encrypt');
+
+  browser.pause(1000);
+
+  // Check there was no error
+  var error = browser.getText('#encryptionOutputError');
+  if (error) throw new Error(error);
+
+  // Check the result looked valid
+  browser.getText('#encryptionOutput').should.not.be.empty;
+}
+
+function checkFingerprintingDoesNotError(browser) {
+  // We have hooked up the #trackFingerprint button to call ravelinjs.trackFingerprint
+  // and provided a callback that writes any resulting errors to #fingerprintError.
+  // No text in #fingerprintError means no error occured fingerprinting the device.
+  // Reference common.js to check out these registrations.
+  browser.click('#trackFingerprint');
+
+  browser.pause(1000);
+
+  var error = browser.getText('#fingerprintError');
+  if (error) throw new Error(error);
+}
+
+function checkTrackingEventsDoNotError(browser) {
+  // We have hooked up the #track, #trackPage, #trackLogin and #trackLogout buttons to call
+  // their respective ravelinjs functions,  and provided a callback that writes any errors to #trackingError.
+  // No text in #trackingError means no error occured fingerprinting the device.
+  // Reference common.js to check out these registrations.
+  var buttons = ['', 'Page', 'Logout']; // Login is not exposed in ravelinjs yet
+
+  for (var i = 0; i < buttons.length; i++) {
+    browser.click('#track' + buttons[i]);
+
+    browser.pause(1000);
+
+    var error = browser.getText('#trackingError');
     if (error) throw new Error(error);
-
-    // Check the result looked valid.
-    browser.getText('#output').should.not.be.empty;
+  }
 }
 
 function usuallyIt(itDoes) {
-    return (itDoes ? it : it.skip).apply(this, Array.prototype.slice.call(arguments, 1));
+  return (itDoes ? it : it.skip).apply(this, Array.prototype.slice.call(arguments, 1));
 }

--- a/test/specs/test.js
+++ b/test/specs/test.js
@@ -28,10 +28,10 @@ describe('ravelinjs', function() {
 });
 
 function suite(browser) {
-  checkIdsAreSet(browser);
   checkCardEncryptionWorks(browser);
   checkFingerprintingDoesNotError(browser);
   checkTrackingEventsDoNotError(browser);
+  checkIdsAreSet(browser); // Check ids last because we have a hack the fingerprint test to ensure they exist
 }
 
 function checkIdsAreSet(browser) {

--- a/test/specs/test.js
+++ b/test/specs/test.js
@@ -28,19 +28,21 @@ describe('ravelinjs', function() {
 });
 
 function suite(browser) {
-  // Do the form.
-  browser.setValue('#name', 'John');
-  browser.setValue('#number', '4111 1111 1111 1111');
-  browser.selectByValue('#month', '4')
-  browser.setValue('#year', '2019');
-  browser.click('#update');
+   // Fill in the card encryption form
+   browser.setValue('#name', 'John');
+   browser.setValue('#number', '4111 1111 1111 1111');
+   browser.selectByValue('#month', '4')
+   browser.setValue('#year', '2019');
+   browser.click('#encrypt');
 
-  // Check there was no error.
-  var error = browser.getText('#output-error');
-  if (error) throw new Error(error);
+   browser.pause(1000);
 
-  // Check the result looked valid.
-  browser.getText('#output').should.not.be.empty;
+   // Check there was no error
+   var error = browser.getText('#encryptionOutputError');
+   if (error) throw new Error(error);
+
+   // Check the result looked valid
+   browser.getText('#encryptionOutput').should.not.be.empty;
 }
 
 function usuallyIt(itDoes) {

--- a/test/specs/test.js
+++ b/test/specs/test.js
@@ -2,91 +2,45 @@ describe('ravelinjs', function() {
   const cap = browser.desiredCapabilities;
 
   it('can be used with a script tag', function() {
-    browser.url('/pages/scripttag/index.html');
-    suite(browser);
+      browser.url('/pages/scripttag/index.html');
+      suite(browser);
   });
 
   it('can be used minified with a script tag', function() {
-    browser.url('/pages/scripttag-min/index.html');
-    suite(browser);
+      browser.url('/pages/scripttag-min/index.html');
+      suite(browser);
   });
 
   usuallyIt(!cap.requireJSTestDisabled, 'can be used with requirejs', function() {
-    browser.url('/pages/amd/index.html');
-    suite(browser);
+      browser.url('/pages/amd/index.html');
+      suite(browser);
   });
 
   usuallyIt(!cap.requireJSTestDisabled, 'can be used minified with requirejs', function() {
-    browser.url('/pages/amd-min/index.html');
-    suite(browser);
+      browser.url('/pages/amd-min/index.html');
+      suite(browser);
   });
 
   usuallyIt(!cap.webpackTestDisabled, 'can be used with webpack', function() {
-    browser.url('/pages/webpack/index.html');
-    suite(browser);
+      browser.url('/pages/webpack/index.html');
+      suite(browser);
   });
 });
 
 function suite(browser) {
-  checkCardEncryptionWorks(browser);
-  checkFingerprintingDoesNotError(browser);
-  checkTrackingEventsDoNotError(browser);
-  checkIdsAreSet(browser); // Check ids last because we have a hack the fingerprint test to ensure they exist
-}
-
-function checkIdsAreSet(browser) {
-  // Ensure that deviceId/sessionId are set upon lib instantiation
-  browser.getText('#deviceId').should.not.be.empty;
-  browser.getText('#sessionId').should.not.be.empty;
-  browser.getText('#cookies').should.not.be.empty;
-}
-
-function checkCardEncryptionWorks(browser) {
-  // Fill in the card encryption form
+  // Do the form.
   browser.setValue('#name', 'John');
   browser.setValue('#number', '4111 1111 1111 1111');
   browser.selectByValue('#month', '4')
   browser.setValue('#year', '2019');
-  browser.click('#encrypt');
+  browser.click('#update');
 
-  browser.pause(1000);
-
-  // Check there was no error
-  var error = browser.getText('#encryptionOutputError');
+  // Check there was no error.
+  var error = browser.getText('#output-error');
   if (error) throw new Error(error);
 
-  // Check the result looked valid
-  browser.getText('#encryptionOutput').should.not.be.empty;
-}
-
-function checkFingerprintingDoesNotError(browser) {
-  // We have hooked up the #trackFingerprint button to call ravelinjs.trackFingerprint
-  // and provided a callback that writes any resulting errors to #fingerprintError.
-  // No text in #fingerprintError means no error occured fingerprinting the device.
-  // Reference common.js to check out these registrations.
-  browser.click('#trackFingerprint');
-
-  browser.pause(1000);
-
-  var error = browser.getText('#fingerprintError');
-  if (error) throw new Error(error);
-}
-
-function checkTrackingEventsDoNotError(browser) {
-  // We have hooked up the #track, #trackPage, #trackLogin and #trackLogout buttons to call
-  // their respective ravelinjs functions,  and provided a callback that writes any errors to #trackingError.
-  // No text in #trackingError means no error occured fingerprinting the device.
-  // Reference common.js to check out these registrations.
-  var buttons = ['', 'Page', 'Logout']; // Login is not exposed in ravelinjs yet
-
-  for (var i = 0; i < buttons.length; i++) {
-    browser.click('#track' + buttons[i]);
-
-    browser.pause(1000);
-
-    var error = browser.getText('#trackingError');
-    if (error) throw new Error(error);
-  }
+  // Check the result looked valid.
+  browser.getText('#output').should.not.be.empty;
 }
 
 function usuallyIt(itDoes) {


### PR DESCRIPTION
Currently, our e2e test only verifies the functionality of card encryption. Ravelinjs does more than just that (although most is controlled via fingerprintjs), so lets add tests for as much as we possibly can.

- Extend 'test pages' to include cookies, deviceId/sessionId, inputs for setters and buttons for submitting API requests
<img width="1419" alt="screenshot 2019-01-07 at 17 08 42" src="https://user-images.githubusercontent.com/12849568/50782078-e9505700-129e-11e9-8fda-b73714fcd508.png">
- Add a common module that instantiates our 'test pages' in a uniform manner

Extensions to e2e tests:
- Set the customerId, orderId and, public API key based off of environment variables passed to the job via the integration-test-service
- Trigger a fingerprint, then write the deviceId to a deviceid.txt artifact
- Trigger 3 session-tracking events, then write the sessionId to a sessionid.txt artifact