### PR TITLE
Wait for element

### DIFF
--- a/test/crossbrowser.conf.js
+++ b/test/crossbrowser.conf.js
@@ -93,9 +93,9 @@ exports.config = Object.assign(base, {
         // Edge.
         {
             build: 'ravelinjs 1.0',
-            name: 'win10 edge18',
+            name: 'win10 edge17',
             browserName: 'MicrosoftEdge',
-            version: '18',
+            version: '17',
             platform: 'Windows 10',
             screenResolution: '1366x768',
         },

--- a/test/crossbrowser.conf.js
+++ b/test/crossbrowser.conf.js
@@ -93,9 +93,9 @@ exports.config = Object.assign(base, {
         // Edge.
         {
             build: 'ravelinjs 1.0',
-            name: 'win10 edge14',
+            name: 'win10 edge18',
             browserName: 'MicrosoftEdge',
-            version: '14',
+            version: '18',
             platform: 'Windows 10',
             screenResolution: '1366x768',
         },

--- a/test/specs/e2e-test.js
+++ b/test/specs/e2e-test.js
@@ -15,7 +15,7 @@ describe('ravelinjs returns the encrypted card details', function() {
 
     it('sets up the RSA key', function() {
         // Wait for the page to load.
-        $('#output').waitForExist();
+        $('#name').waitForExist();
 
         // Set the key.
         const demoKeyMsg = browser.getText('#output');
@@ -38,7 +38,7 @@ describe('ravelinjs returns the encrypted card details', function() {
 
     it('encrypts the cardholder data', function() {
         // Wait for the page to load.
-        $('#output').waitForExist();
+        $('#name').waitForExist();
 
         // Encrypt the card data.
         browser.setValue('#name', nameOnCard);

--- a/test/specs/e2e-test.js
+++ b/test/specs/e2e-test.js
@@ -14,6 +14,9 @@ describe('ravelinjs returns the encrypted card details', function() {
     });
 
     it('sets up the RSA key', function() {
+        // Wait for the page to load.
+        $('#output').waitForExist();
+
         // Set the key.
         const demoKeyMsg = browser.getText('#output');
         browser.setValue('#rsa-key', rsaKey);
@@ -34,6 +37,9 @@ describe('ravelinjs returns the encrypted card details', function() {
     var ciphertext;
 
     it('encrypts the cardholder data', function() {
+        // Wait for the page to load.
+        $('#output').waitForExist();
+
         // Encrypt the card data.
         browser.setValue('#name', nameOnCard);
         browser.setValue('#number', '4111 1111 1111 1111');

--- a/test/specs/test.js
+++ b/test/specs/test.js
@@ -28,8 +28,8 @@ describe('ravelinjs', function() {
 });
 
 function suite(browser) {
-    // Ensure the page has loaded.
-    $('#never-found').waitForExist();
+    // Wait for the page to load.
+    $('#name').waitForExist();
 
     // Do the form.
     browser.setValue('#name', 'John');

--- a/test/specs/test.js
+++ b/test/specs/test.js
@@ -28,6 +28,9 @@ describe('ravelinjs', function() {
 });
 
 function suite(browser) {
+    // Ensure the page has loaded.
+    $('#never-found').waitForExist();
+
     // Do the form.
     browser.setValue('#name', 'John');
     browser.setValue('#number', '4111 1111 1111 1111');


### PR DESCRIPTION
We saw a couple of scheduled end-to-end tests failing on elements not existing, probably because we attempted to initiate the test suite before the page had finished loading.

```
[Chrome latest Windows 10 #0-0] ravelinjs returns the encrypted card details
[Chrome latest Windows 10 #0-0]   ✓ loads the page
[Chrome latest Windows 10 #0-0]   1) sets up the RSA key
[Chrome latest Windows 10 #0-0]   2) encrypts the cardholder data
[Chrome latest Windows 10 #0-0]   ✓ writes the cipher to a local file
[Chrome latest Windows 10 #0-0]
[Chrome latest Windows 10 #0-0]
[Chrome latest Windows 10 #0-0] 2 passing (10s)
[Chrome latest Windows 10 #0-0] 2 failing
[Chrome latest Windows 10 #0-0]
[Chrome latest Windows 10 #0-0] 1) ravelinjs returns the encrypted card details sets up the RSA key:
[Chrome latest Windows 10 #0-0] An element could not be located on the page using the given search parameters ("#output").
[Chrome latest Windows 10 #0-0] Error: An element could not be located on the page using the given search parameters ("#output").
[Chrome latest Windows 10 #0-0]     at getText("#output") - at elements("#output") - getText.js:18:17
[Chrome latest Windows 10 #0-0]
[Chrome latest Windows 10 #0-0] 2) ravelinjs returns the encrypted card details encrypts the cardholder data:
[Chrome latest Windows 10 #0-0] An element could not be located on the page using the given search parameters ("#name").
[Chrome latest Windows 10 #0-0] Error: An element could not be located on the page using the given search parameters ("#name").
[Chrome latest Windows 10 #0-0]     at setValue("#name", "Phở Dặc Biệt vZYXEDaqbsnlLjYV") - at elements("#name") - setValue.js:29:17
[Chrome latest Windows 10 #0-0]
```

Now we'll wait for the necessary elements to be available before starting.