### PR TITLE
Time out each automated test case after 120s.

### DIFF
--- a/test/base.conf.js
+++ b/test/base.conf.js
@@ -220,7 +220,7 @@ exports.config = {
 
         /**
          * browser.waitForURL navigates to url and waits until the browser URL
-         * starts with url, timing out after timeout or 10000 milliseconds.
+         * contains it, timing out after timeout or 10000 milliseconds.
          */
         browser.addCommand('waitForURL', function(url, timeout) {
             let latest = '(none)';
@@ -229,7 +229,7 @@ exports.config = {
                 return browser.waitUntil(
                     function () {
                         latest = browser.getUrl();
-                        return latest.indexOf(url) == 0;
+                        return latest.indexOf(url) > -1;
                     },
                     timeout || 10000,
                     'timeout'

--- a/test/base.conf.js
+++ b/test/base.conf.js
@@ -218,7 +218,35 @@ exports.config = {
         global.expect = chai.expect;
         chai.Should();
 
-        // Set up a custom URL helper.
+        /**
+         * browser.waitForURL navigates to url and waits until the browser URL
+         * starts with url, timing out after timeout or 10000 milliseconds.
+         */
+        browser.addCommand('waitForURL', function(url, timeout) {
+            value = encodeURIComponent(value).replace('%20', '+');
+            const targetParam = new RegExp('[&?]' + (param + '=' + value).replace(/([.*+?^=!:${}()|\[\]\/\\])/g, "\\$1") + '(&|$)');
+
+            var latest;
+            try {
+                browser.url(url);
+                return browser.waitUntil(
+                    function () {
+                        return browser.getUrl().indexOf(url) == 0;
+                    },
+                    timeout || 10000,
+                    'timeout'
+                );
+            } catch (e) {
+                if (e.message == 'timeout') {
+                    throw new Error("Timed out waiting for URL with query param " + param + "=" + value + ". Last URL was " + latest);
+                }
+                throw e;
+            }
+        });
+        /**
+         * browser.waitForQueryParam waits for the browser URL to define
+         * param=value in the query string.
+         */
         browser.addCommand('waitForQueryParam', function(param, value, timeout) {
             value = encodeURIComponent(value).replace('%20', '+');
             const targetParam = new RegExp('[&?]' + (param + '=' + value).replace(/([.*+?^=!:${}()|\[\]\/\\])/g, "\\$1") + '(&|$)');

--- a/test/base.conf.js
+++ b/test/base.conf.js
@@ -223,22 +223,20 @@ exports.config = {
          * starts with url, timing out after timeout or 10000 milliseconds.
          */
         browser.addCommand('waitForURL', function(url, timeout) {
-            value = encodeURIComponent(value).replace('%20', '+');
-            const targetParam = new RegExp('[&?]' + (param + '=' + value).replace(/([.*+?^=!:${}()|\[\]\/\\])/g, "\\$1") + '(&|$)');
-
-            var latest;
+            let latest = '(none)';
             try {
                 browser.url(url);
                 return browser.waitUntil(
                     function () {
-                        return browser.getUrl().indexOf(url) == 0;
+                        latest = browser.getUrl();
+                        return latest.indexOf(url) == 0;
                     },
                     timeout || 10000,
                     'timeout'
                 );
             } catch (e) {
                 if (e.message == 'timeout') {
-                    throw new Error("Timed out waiting for URL with query param " + param + "=" + value + ". Last URL was " + latest);
+                    throw new Error("Timed out waiting for URL starting " + url + ". Last URL was " + latest);
                 }
                 throw e;
             }

--- a/test/base.conf.js
+++ b/test/base.conf.js
@@ -231,7 +231,7 @@ exports.config = {
                         latest = browser.getUrl();
                         return latest.indexOf(url) > -1;
                     },
-                    timeout || 10000,
+                    timeout,
                     'timeout'
                 );
             } catch (e) {
@@ -256,7 +256,7 @@ exports.config = {
                         latest = browser.getUrl();
                         return targetParam.test(latest);
                     },
-                    timeout || 10000,
+                    timeout,
                     'timeout'
                 );
             } catch (e) {

--- a/test/crossbrowser.conf.js
+++ b/test/crossbrowser.conf.js
@@ -8,6 +8,8 @@ if (!user || !key) {
     throw new Error('Set the CROSSBROWSERTESTING_USER and CROSSBROWSERTESTING_KEY envvars.');
 }
 
+process.env.BROWSERS = "safari"
+
 const base = require('./base.conf').config;
 exports.config = Object.assign(base, {
     // Appium desktop defaults.

--- a/test/crossbrowser.conf.js
+++ b/test/crossbrowser.conf.js
@@ -154,11 +154,15 @@ exports.config = Object.assign(base, {
           platformVersion: '11.0',
           platformName: 'iOS',
           deviceOrientation: 'portrait',
+
+          max_duration: 180,
+          navigateTimeoutMS: 60000,
+          renderTimeoutMS: 60000,
         },
-    ].map(c => {
+    ].map(function(c) {
         // Apply a maximum duration of 1 minute to each test case.
-        c.max_duration = 120
-        return c
+        c.max_duration = c.max_duration || 120;
+        return c;
     }).filter(
         // Filter the capabilities by name if there's a BROWSERS envvar.
         !process.env.BROWSERS ? () => true : (b) => !!~b.name.toLowerCase().indexOf(process.env.BROWSERS.toLowerCase())

--- a/test/crossbrowser.conf.js
+++ b/test/crossbrowser.conf.js
@@ -8,6 +8,8 @@ if (!user || !key) {
     throw new Error('Set the CROSSBROWSERTESTING_USER and CROSSBROWSERTESTING_KEY envvars.');
 }
 
+const timeoutSeconds = 120;
+
 const base = require('./base.conf').config;
 exports.config = Object.assign(base, {
     // Appium desktop defaults.
@@ -18,6 +20,14 @@ exports.config = Object.assign(base, {
 
     // Picked up by cbt_tunnels.
     baseUrl: 'http://local',
+
+    // Bail after the first test failure. The cost of running many tests is too
+    // high, and it takes too damn long.
+    bail: 1,
+    // Up the test timeout to 60s.
+    mochaOpts: Object.assign(base.mochaOpts, {
+      timeout: timeoutSeconds * 1000,
+    }),
 
     maxInstances: parseInt(process.env.WD_PARALLEL, 10) || 1,
     capabilities: [
@@ -162,7 +172,7 @@ exports.config = Object.assign(base, {
         },
     ].map(function(c) {
         // Apply a maximum duration of 1 minute to each test case.
-        c.max_duration = c.max_duration || 120;
+        c.max_duration = c.max_duration || timeoutSeconds;
         return c;
     }).filter(
         // Filter the capabilities by name if there's a BROWSERS envvar.

--- a/test/crossbrowser.conf.js
+++ b/test/crossbrowser.conf.js
@@ -24,9 +24,9 @@ exports.config = Object.assign(base, {
     // Bail after the first test failure. The cost of running many tests is too
     // high, and it takes too damn long.
     bail: 1,
-    // Up the test timeout to 60s.
     mochaOpts: Object.assign(base.mochaOpts, {
-      timeout: timeoutSeconds * 1000,
+        // Match mocha timeout with browser.
+        timeout: timeoutSeconds * 1000,
     }),
 
     maxInstances: parseInt(process.env.WD_PARALLEL, 10) || 1,

--- a/test/crossbrowser.conf.js
+++ b/test/crossbrowser.conf.js
@@ -141,6 +141,7 @@ exports.config = Object.assign(base, {
         // Android
         {
           build: 'ravelinjs 1.0',
+          name: 'android6 chromeLatest',
           browserName: 'Chrome',
           deviceName: 'Nexus 9',
           platformVersion: '6.0',

--- a/test/crossbrowser.conf.js
+++ b/test/crossbrowser.conf.js
@@ -8,8 +8,6 @@ if (!user || !key) {
     throw new Error('Set the CROSSBROWSERTESTING_USER and CROSSBROWSERTESTING_KEY envvars.');
 }
 
-process.env.BROWSERS = "safari"
-
 const base = require('./base.conf').config;
 exports.config = Object.assign(base, {
     // Appium desktop defaults.

--- a/test/crossbrowser.conf.js
+++ b/test/crossbrowser.conf.js
@@ -149,10 +149,10 @@ exports.config = Object.assign(base, {
         // Android
         {
           build: 'ravelinjs 1.0',
-          name: 'android6 chromeLatest',
+          name: 'android5 chromeLatest',
           browserName: 'Chrome',
-          deviceName: 'Nexus 9',
-          platformVersion: '6.0',
+          deviceName: 'Nexus 6',
+          platformVersion: '5.0',
           platformName: 'Android',
           deviceOrientation: 'portrait',
         },

--- a/test/crossbrowser.conf.js
+++ b/test/crossbrowser.conf.js
@@ -155,7 +155,11 @@ exports.config = Object.assign(base, {
           platformName: 'iOS',
           deviceOrientation: 'portrait',
         },
-    ].filter(
+    ].map(c => {
+        // Apply a maximum duration of 1 minute to each test case.
+        c.max_duration = 60
+        return c
+    }).filter(
         // Filter the capabilities by name if there's a BROWSERS envvar.
         !process.env.BROWSERS ? () => true : (b) => !!~b.name.toLowerCase().indexOf(process.env.BROWSERS.toLowerCase())
     ),

--- a/test/crossbrowser.conf.js
+++ b/test/crossbrowser.conf.js
@@ -157,7 +157,7 @@ exports.config = Object.assign(base, {
         },
     ].map(c => {
         // Apply a maximum duration of 1 minute to each test case.
-        c.max_duration = 60
+        c.max_duration = 120
         return c
     }).filter(
         // Filter the capabilities by name if there's a BROWSERS envvar.

--- a/test/specs/test.js
+++ b/test/specs/test.js
@@ -3,31 +3,31 @@ describe('ravelinjs', function() {
 
     it('can be used with a script tag', function() {
         browser.waitForURL('/pages/scripttag/index.html', cap.navigateTimeoutMS);
-        suite(browser);
+        suite(browser, cap);
     });
 
     it('can be used minified with a script tag', function() {
         browser.waitForURL('/pages/scripttag-min/index.html', cap.navigateTimeoutMS);
-        suite(browser);
+        suite(browser, cap);
     });
 
     usuallyIt(!cap.requireJSTestDisabled, 'can be used with requirejs', function() {
         browser.waitForURL('/pages/amd/index.html', cap.navigateTimeoutMS);
-        suite(browser);
+        suite(browser, cap);
     });
 
     usuallyIt(!cap.requireJSTestDisabled, 'can be used minified with requirejs', function() {
         browser.waitForURL('/pages/amd-min/index.html', cap.navigateTimeoutMS);
-        suite(browser);
+        suite(browser, cap);
     });
 
     usuallyIt(!cap.webpackTestDisabled, 'can be used with webpack', function() {
         browser.waitForURL('/pages/webpack/index.html', cap.navigateTimeoutMS);
-        suite(browser);
+        suite(browser, cap);
     });
 });
 
-function suite(browser) {
+function suite(browser, cap) {
     // Wait for the page to load.
     $('#name').waitForExist(cap.renderTimeoutMS);
 

--- a/test/specs/test.js
+++ b/test/specs/test.js
@@ -2,34 +2,34 @@ describe('ravelinjs', function() {
     const cap = browser.desiredCapabilities;
 
     it('can be used with a script tag', function() {
-        browser.url('/pages/scripttag/index.html');
+        browser.waitForURL('/pages/scripttag/index.html', cap.navigateTimeoutMS);
         suite(browser);
     });
 
     it('can be used minified with a script tag', function() {
-        browser.url('/pages/scripttag-min/index.html');
+        browser.waitForURL('/pages/scripttag-min/index.html', cap.navigateTimeoutMS);
         suite(browser);
     });
 
     usuallyIt(!cap.requireJSTestDisabled, 'can be used with requirejs', function() {
-        browser.url('/pages/amd/index.html');
+        browser.waitForURL('/pages/amd/index.html', cap.navigateTimeoutMS);
         suite(browser);
     });
 
     usuallyIt(!cap.requireJSTestDisabled, 'can be used minified with requirejs', function() {
-        browser.url('/pages/amd-min/index.html');
+        browser.waitForURL('/pages/amd-min/index.html', cap.navigateTimeoutMS);
         suite(browser);
     });
 
     usuallyIt(!cap.webpackTestDisabled, 'can be used with webpack', function() {
-        browser.url('/pages/webpack/index.html');
+        browser.waitForURL('/pages/webpack/index.html', cap.navigateTimeoutMS);
         suite(browser);
     });
 });
 
 function suite(browser) {
     // Wait for the page to load.
-    $('#name').waitForExist();
+    $('#name').waitForExist(cap.renderTimeoutMS);
 
     // Do the form.
     browser.setValue('#name', 'John');


### PR DESCRIPTION
Changed each browser test to time out after 2 minutes (`mochaOpts.timeout`), and automatically shut down the instance after that time (capability's `max_duration`). This should resolve the case of any lingering browsers preventing further browsers being opened.

On a per-test basis, we now double-check that we're on URL we expect (capability `navigateTimeoutMS`) before checking that the element on page is available (capability `renderTimeoutMS`). I suspect that the elements were not being found because the page could not be loaded, due to some instability somewhere in the crossbrowsertesting ↔ cbt_tunnels ↔ CircleCI journey.

I've also changed crossbrowsertesting.com tests to immediately fail on the first test failure.