### PR TITLE
Disabled circleci cache restore.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,11 +16,11 @@ jobs:
       - checkout
 
       # Download and cache dependencies
-      - restore_cache:
-          keys:
-          - v1-dependencies-{{ checksum "package.json" }}
-          # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
+      # - restore_cache:
+      #     keys:
+      #     - v1-dependencies-{{ checksum "package.json" }}
+      #     # fallback to using the latest cache if no exact match is found
+      #     - v1-dependencies-
 
       - run: npm install
 

--- a/test/crossbrowser.conf.js
+++ b/test/crossbrowser.conf.js
@@ -48,9 +48,9 @@ exports.config = Object.assign(base, {
         // },
         {
             build: 'ravelinjs 1.0',
-            name: 'win8 chrome18',
+            name: 'win8 chrome50',
             browserName: 'Chrome',
-            version: '18',
+            version: '50',
             platform: 'Windows 8',
         },
         // Safari.


### PR DESCRIPTION
After restoring the cache we receive the following error during npm i:

    Error trying to install Chromedriver binary. Waiting and trying
    again.  Cannot find module 'lodash/object/assign'