### PR TITLE
core: Option to bring your own ID. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,14 @@ var rav = new Ravelin({
      */
     // api: 'https://live.ravelin.click/',
     /**
+     * @prop {string|Promise<string>} [id] An explicit deviceId to use. If set,
+     * Ravelin won't attempt to maintain a deviceId of its own. However, if the
+     * given Promise errors or resolves to an empty value, we fall back to the
+     * built-in behaviour.
+     */
+    // id: 'my-device-id',
+    // id: new Promise(r => r('my-device-id')),
+    /**
      * @prop {number} [idExpiryDays] The number of days that a device ID will live.
      * Defaults to 365 in accordance with the GDPR's ePrivacy Directive.
      */

--- a/README.md
+++ b/README.md
@@ -165,6 +165,11 @@ var rav = new Ravelin({
     // id: 'my-device-id',
     // id: new Promise(r => r('my-device-id')),
     /**
+     * @prop {string} [cookie=ravelinDeviceId] The cookie that the deviceId is
+     * persisted in.
+     */
+    // cookie: 'my-guid',
+    /**
      * @prop {number} [cookieExpiryDays] The number of days that a device ID will live.
      * Defaults to 365 in accordance with the GDPR's ePrivacy Directive.
      */

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ var rav = new Ravelin({
     /**
      * @prop {PromiseConstructor} [Promise] An injectable Promise implementation
      * to use. If not provided, defaults to window.Promise or a polyfill if the
-     * +promise component is included.
+     * +promise component is included. Ravelin.Promise contains the default.
      */
     // Promise: window.Promise,
 

--- a/README.md
+++ b/README.md
@@ -165,10 +165,10 @@ var rav = new Ravelin({
     // id: 'my-device-id',
     // id: new Promise(r => r('my-device-id')),
     /**
-     * @prop {number} [idExpiryDays] The number of days that a device ID will live.
+     * @prop {number} [cookieExpiryDays] The number of days that a device ID will live.
      * Defaults to 365 in accordance with the GDPR's ePrivacy Directive.
      */
-    // idExpiryDays: 365,
+    // cookieExpiryDays: 365,
     /**
      * @prop {string} [cookieDomain] The top-most domain that we can store
      * cookies on. If you expect your customer to navigate between multiple

--- a/lib/bundle/core+encrypt+promise.js
+++ b/lib/bundle/core+encrypt+promise.js
@@ -6,7 +6,7 @@ import Promise from '../promise';
   * @param {object} [cfg]
   */
 function Ravelin(cfg) {
-  cfg.Promise = cfg.Promise || Ravelin.Promise || window.Promise || Promise;
+  cfg.Promise = cfg.Promise || Ravelin.Promise;
   this.core = new Core(cfg);
   this.encrypt = new Encrypt(this.core, cfg);
 }

--- a/lib/bundle/core+encrypt+promise.js
+++ b/lib/bundle/core+encrypt+promise.js
@@ -5,8 +5,12 @@ import Promise from '../promise';
  /**
   * @param {object} [cfg]
   */
-export default function Ravelin(cfg) {
-  cfg.Promise = cfg.Promise || window.Promise || Promise;
+function Ravelin(cfg) {
+  cfg.Promise = cfg.Promise || Ravelin.Promise || window.Promise || Promise;
   this.core = new Core(cfg);
   this.encrypt = new Encrypt(this.core, cfg);
 }
+
+Ravelin.Promise = window.Promise || Promise;
+
+export default Ravelin;

--- a/lib/bundle/core+encrypt.js
+++ b/lib/bundle/core+encrypt.js
@@ -4,7 +4,12 @@ import { Encrypt } from '../encrypt';
  /**
   * @param {object} [cfg]
   */
-export default function Ravelin(cfg) {
+function Ravelin(cfg) {
+  cfg.Promise = cfg.Promise || Ravelin.Promise;
   this.core = new Core(cfg);
   this.encrypt = new Encrypt(this.core, cfg);
 }
+
+Ravelin.Promise = window.Promise;
+
+export default Ravelin;

--- a/lib/bundle/core+promise.js
+++ b/lib/bundle/core+promise.js
@@ -5,7 +5,7 @@ import Promise from '../promise';
   * @param {object} [cfg]
   */
 function Ravelin(cfg) {
-  cfg.Promise = cfg.Promise || Ravelin.Promise || window.Promise || Promise;
+  cfg.Promise = cfg.Promise || Ravelin.Promise;
   this.core = new Core(cfg);
 }
 

--- a/lib/bundle/core+promise.js
+++ b/lib/bundle/core+promise.js
@@ -4,7 +4,11 @@ import Promise from '../promise';
  /**
   * @param {object} [cfg]
   */
-export default function Ravelin(cfg) {
-  cfg.Promise = cfg.Promise || window.Promise || Promise;
+function Ravelin(cfg) {
+  cfg.Promise = cfg.Promise || Ravelin.Promise || window.Promise || Promise;
   this.core = new Core(cfg);
 }
+
+Ravelin.Promise = window.Promise || Promise;
+
+export default Ravelin;

--- a/lib/bundle/core+track+encrypt+promise.js
+++ b/lib/bundle/core+track+encrypt+promise.js
@@ -17,7 +17,7 @@ import Promise from '../promise';
   * @param {Config} [cfg]
   */
 function Ravelin(cfg) {
-  cfg.Promise = cfg.Promise || window.Promise || Promise;
+  cfg.Promise = cfg.Promise || Ravelin.Promise || window.Promise || Promise;
   /** @prop {Core} core */
   this.core = new Core(cfg);
   /** @prop {Track} track */
@@ -25,5 +25,7 @@ function Ravelin(cfg) {
   /** @prop {Encrypt} encrypt */
   this.encrypt = new Encrypt(this.core, cfg);
 }
+
+Ravelin.Promise = window.Promise || Promise;
 
 export default Ravelin;

--- a/lib/bundle/core+track+encrypt+promise.js
+++ b/lib/bundle/core+track+encrypt+promise.js
@@ -17,7 +17,7 @@ import Promise from '../promise';
   * @param {Config} [cfg]
   */
 function Ravelin(cfg) {
-  cfg.Promise = cfg.Promise || Ravelin.Promise || window.Promise || Promise;
+  cfg.Promise = cfg.Promise || Ravelin.Promise;
   /** @prop {Core} core */
   this.core = new Core(cfg);
   /** @prop {Track} track */

--- a/lib/bundle/core+track+encrypt.js
+++ b/lib/bundle/core+track+encrypt.js
@@ -6,7 +6,7 @@ import { Encrypt } from '../encrypt';
   * @param {object} [cfg]
   */
 function Ravelin(cfg) {
-  cfg.Promise = Ravelin.Promise;
+  cfg.Promise = cfg.Promise || Ravelin.Promise;
   this.core = new Core(cfg);
   this.track = new Track(this.core, cfg);
   this.encrypt = new Encrypt(this.core, cfg);

--- a/lib/bundle/core+track+encrypt.js
+++ b/lib/bundle/core+track+encrypt.js
@@ -5,8 +5,13 @@ import { Encrypt } from '../encrypt';
  /**
   * @param {object} [cfg]
   */
-export default function Ravelin(cfg) {
+function Ravelin(cfg) {
+  cfg.Promise = Ravelin.Promise;
   this.core = new Core(cfg);
   this.track = new Track(this.core, cfg);
   this.encrypt = new Encrypt(this.core, cfg);
 }
+
+Ravelin.Promise = window.Promise;
+
+export default Ravelin;

--- a/lib/bundle/core+track+promise.js
+++ b/lib/bundle/core+track+promise.js
@@ -5,8 +5,12 @@ import Promise from '../promise';
  /**
   * @param {object} [cfg]
   */
-export default function Ravelin(cfg) {
-  cfg.Promise = cfg.Promise || window.Promise || Promise;
+function Ravelin(cfg) {
+  cfg.Promise = cfg.Promise || Ravelin.Promise || window.Promise || Promise;
   this.core = new Core(cfg);
   this.track = new Track(this.core, cfg);
 }
+
+Ravelin.Promise = window.Promise || Promise;
+
+export default Ravelin;

--- a/lib/bundle/core+track+promise.js
+++ b/lib/bundle/core+track+promise.js
@@ -6,7 +6,7 @@ import Promise from '../promise';
   * @param {object} [cfg]
   */
 function Ravelin(cfg) {
-  cfg.Promise = cfg.Promise || Ravelin.Promise || window.Promise || Promise;
+  cfg.Promise = cfg.Promise || Ravelin.Promise;
   this.core = new Core(cfg);
   this.track = new Track(this.core, cfg);
 }

--- a/lib/bundle/core+track.js
+++ b/lib/bundle/core+track.js
@@ -5,7 +5,7 @@ import { Track } from '../track';
   * @param {object} [cfg]
   */
 function Ravelin(cfg) {
-  cfg.Promise = Ravelin.Promise;
+  cfg.Promise = cfg.Promise || Ravelin.Promise;
   this.core = new Core(cfg);
   this.track = new Track(this.core, cfg);
 }

--- a/lib/bundle/core+track.js
+++ b/lib/bundle/core+track.js
@@ -4,7 +4,12 @@ import { Track } from '../track';
  /**
   * @param {object} [cfg]
   */
-export default function Ravelin(cfg) {
+function Ravelin(cfg) {
+  cfg.Promise = Ravelin.Promise;
   this.core = new Core(cfg);
   this.track = new Track(this.core, cfg);
 }
+
+Ravelin.Promise = window.Promise;
+
+export default Ravelin;

--- a/lib/bundle/core.js
+++ b/lib/bundle/core.js
@@ -3,6 +3,11 @@ import { Core } from '../core';
  /**
   * @param {object} [cfg]
   */
-export default function Ravelin(cfg) {
+function Ravelin(cfg) {
+  cfg.Promise = cfg.Promise || Ravelin.Promise;
   this.core = new Core(cfg);
 }
+
+Ravelin.Promise = window.Promise;
+
+export default Ravelin;

--- a/lib/core.js
+++ b/lib/core.js
@@ -63,11 +63,14 @@ Core.prototype._idBackup = function(id) {
     that.sync();
     return that.id();
   }
-  return that.sniffError(function() {
-    return new that.Promise(function(resolve) {
+
+  var p = id;
+  if (!p.then) {
+    p = new that.Promise(function(resolve) {
       resolve(id);
     });
-  }).then(
+  }
+  return p.then(
     function(id) {
       if (id) return id;
       return backup();

--- a/lib/core.js
+++ b/lib/core.js
@@ -17,7 +17,7 @@ import { promiseRetry, bind, uuid } from './util';
  * @prop {number} [cookieExpiryDays=365] The max lifetime of a deviceId, in days.
  * @prop {number} [syncMs=2000] The sync timeout frequency.
  * @prop {number} [sendRetryMs=150] The send retry backoff time.
- * @prop {PromiseConstructor} Promise The Promise implementation to use in ravelinjs's asychnrous functions.
+ * @prop {PromiseConstructor} [Promise] The Promise implementation to use in ravelinjs's asynchronous functions.
  */
 
 /**

--- a/lib/core.js
+++ b/lib/core.js
@@ -64,12 +64,9 @@ Core.prototype._idBackup = function(id) {
     return that.id();
   }
 
-  var p = id;
-  if (!p.then) {
-    p = new that.Promise(function(resolve) {
-      resolve(id);
-    });
-  }
+  var p = id.then ?
+    this.sniffError(function() { return id; }) :
+    new this.Promise(function(r) { r(id); });
   return p.then(
     function(id) {
       if (id) return id;

--- a/lib/core.js
+++ b/lib/core.js
@@ -16,10 +16,7 @@ import { promiseRetry, bind, uuid } from './util';
  * @prop {number} [idExpiryDays=365] The max lifetime of a deviceId, in days.
  * @prop {number} [syncMs=2000] The sync timeout frequency.
  * @prop {number} [sendRetryMs=150] The send retry backoff time.
- * @prop {PromiseConstructor} [Promise=Promise]
- *    The Promise implementation to use in ravelinjs's asychnrous functions.
- *    Defaults to the browser's own Promise if not set. Automatically set if you
- *    include the module for compatiblity with Internet Explorer.
+ * @prop {PromiseConstructor} Promise The Promise implementation to use in ravelinjs's asychnrous functions.
  */
 
 /**
@@ -28,7 +25,7 @@ import { promiseRetry, bind, uuid } from './util';
  * @param {CoreConfig} cfg
  */
 export function Core(cfg) {
-  this.Promise = cfg.Promise || window.Promise;
+  this.Promise = cfg.Promise;
 
   // API connectivity.
   this.key = cfg.key;

--- a/lib/core.js
+++ b/lib/core.js
@@ -12,6 +12,7 @@ import { promiseRetry, bind, uuid } from './util';
  * @prop {string} [key] The API key ("publishable_key_..." or "pk_...") used to authenticate with the Ravelin API.
  * @prop {string} [api] A string of the format "https://api.ravelin.net" which forms the base of API requests.
  * @prop {string|Promise<string>} [id] An explicit deviceId to use. If the Promise errors or returns an empty value, Ravelin's own deviceId tracking kicks in.
+ * @prop {string} [cookie=ravelinDeviceId] The name of the cookie that the deviceId is kept in.
  * @prop {string} [cookieDomain] The domain on which to set cookies. Ignored if invalid.
  * @prop {number} [cookieExpiryDays=365] The max lifetime of a deviceId, in days.
  * @prop {number} [syncMs=2000] The sync timeout frequency.
@@ -32,6 +33,7 @@ export function Core(cfg) {
   this.api = cfg.api || apiFromKey(this.key);
   this.api = this.api[0] + this.api.substr(1).replace(/^\/+|\/$/g, '');
   this.sendRetryMs = cfg.sendRetryMs || 150;
+  this.cookie = cfg.cookie || 'ravelinDeviceId';
   this.cookieExpiryDays = cfg.cookieExpiryDays || 365;
   this.cookies = new CookieJar({
     domain: cfg.cookieDomain
@@ -81,8 +83,6 @@ Core.prototype._idBackup = function(id) {
   );
 };
 
-var deviceIdCookie = 'ravelinDeviceId';
-
 /**
  * id reads our device identity from the browser.
  * @fulfil {string} The device ID.
@@ -97,7 +97,7 @@ Core.prototype.id = function() {
   var c = this;
   this._id = this.sniffError(function() {
     return new c.Promise(function(resolve) {
-      resolve(c.cookies.get(deviceIdCookie) || 'rjs-' + uuid());
+      resolve(c.cookies.get(c.cookie) || 'rjs-' + uuid());
     });
   });
   return this._id;
@@ -116,11 +116,11 @@ function daysFromNow(days) {
  * sync writes our ID into the various places we try to keep hold of it.
  */
 Core.prototype.sync = function() {
-  var c = this.cookies;
+  var c = this;
   var ttlDays = this.cookieExpiryDays;
   return this.id().then(function(id) {
-    c.set({
-      name: deviceIdCookie,
+    c.cookies.set({
+      name: c.cookie,
       value: id,
       expires: daysFromNow(ttlDays)
     });

--- a/lib/core.js
+++ b/lib/core.js
@@ -13,7 +13,7 @@ import { promiseRetry, bind, uuid } from './util';
  * @prop {string} [api] A string of the format "https://api.ravelin.net" which forms the base of API requests.
  * @prop {string|Promise<string>} [id] An explicit deviceId to use. If the Promise errors or returns an empty value, Ravelin's own deviceId tracking kicks in.
  * @prop {string} [cookieDomain] The domain on which to set cookies. Ignored if invalid.
- * @prop {number} [idExpiryDays=365] The max lifetime of a deviceId, in days.
+ * @prop {number} [cookieExpiryDays=365] The max lifetime of a deviceId, in days.
  * @prop {number} [syncMs=2000] The sync timeout frequency.
  * @prop {number} [sendRetryMs=150] The send retry backoff time.
  * @prop {PromiseConstructor} Promise The Promise implementation to use in ravelinjs's asychnrous functions.
@@ -32,7 +32,7 @@ export function Core(cfg) {
   this.api = cfg.api || apiFromKey(this.key);
   this.api = this.api[0] + this.api.substr(1).replace(/^\/+|\/$/g, '');
   this.sendRetryMs = cfg.sendRetryMs || 150;
-  this.idExpiryDays = cfg.idExpiryDays || 365;
+  this.cookieExpiryDays = cfg.cookieExpiryDays || 365;
   this.cookies = new CookieJar({
     domain: cfg.cookieDomain
   });
@@ -117,7 +117,7 @@ function daysFromNow(days) {
  */
 Core.prototype.sync = function() {
   var c = this.cookies;
-  var ttlDays = this.idExpiryDays;
+  var ttlDays = this.cookieExpiryDays;
   return this.id().then(function(id) {
     c.set({
       name: deviceIdCookie,

--- a/lib/core.js
+++ b/lib/core.js
@@ -64,10 +64,18 @@ Core.prototype._idBackup = function(id) {
     return that.id();
   }
 
-  var p = id.then ?
-    this.sniffError(function() { return id; }) :
-    new this.Promise(function(r) { r(id); });
-  return p.then(
+  // We could have handled id the same way - whether string or Promise - if new
+  // Promise(r => r(id)).then(sid => ...) always resolved to a string sid, but
+  // the Yaku Promise implementation we bundle doesn't unwrap the Promise id
+  // resolved in the constructor. So instead, we look for something then-able.
+  if (!id.then) {
+    return new this.Promise(function(r) { r(id); });
+  }
+
+  // Wrap the Promise id to ensure we never get an empty deviceId.
+  return this.sniffError(function() {
+    return id;
+  }).then(
     function(id) {
       if (id) return id;
       return backup();

--- a/lib/core.js
+++ b/lib/core.js
@@ -11,8 +11,9 @@ import { promiseRetry, bind, uuid } from './util';
  * @typedef {object} CoreConfig
  * @prop {string} [key] The API key ("publishable_key_..." or "pk_...") used to authenticate with the Ravelin API.
  * @prop {string} [api] A string of the format "https://api.ravelin.net" which forms the base of API requests.
- * @prop {number} [idExpiryDays=365] The max lifetime of a deviceId, in days.
+ * @prop {string|Promise<string>} [id] An explicit deviceId to use. If the Promise errors or returns an empty value, Ravelin's own deviceId tracking kicks in.
  * @prop {string} [cookieDomain] The domain on which to set cookies. Ignored if invalid.
+ * @prop {number} [idExpiryDays=365] The max lifetime of a deviceId, in days.
  * @prop {number} [syncMs=2000] The sync timeout frequency.
  * @prop {number} [sendRetryMs=150] The send retry backoff time.
  * @prop {PromiseConstructor} [Promise=Promise]
@@ -35,16 +36,45 @@ export function Core(cfg) {
   this.api = this.api[0] + this.api.substr(1).replace(/^\/+|\/$/g, '');
   this.sendRetryMs = cfg.sendRetryMs || 150;
   this.idExpiryDays = cfg.idExpiryDays || 365;
-
-  // Device IDs.
   this.cookies = new CookieJar({
     domain: cfg.cookieDomain
   });
-  this.sync();
-  if (cfg.init !== false) {
-    this.attach(cfg.syncMs || 2000);
+
+  if (cfg.id) {
+    this._id = this._idBackup(cfg.id);
+  } else {
+    this.sync();
+    if (cfg.init !== false) {
+      this.attach(cfg.syncMs || 2000);
+    }
   }
 }
+
+/**
+ * _idBackup wraps the user-given id, providing error reporting and a non-empty
+ * fallback in-case it errors or provides an empty value.
+ * @param {string|Promise<string>} id
+ * @returns {Promise<string>}
+ */
+Core.prototype._idBackup = function(id) {
+  var that = this;
+  function backup() {
+    that._id = null;
+    that.sync();
+    return that.id();
+  }
+  return that.sniffError(function() {
+    return new that.Promise(function(resolve) {
+      resolve(id);
+    });
+  }).then(
+    function(id) {
+      if (id) return id;
+      return backup();
+    },
+    backup
+  );
+};
 
 var deviceIdCookie = 'ravelinDeviceId';
 
@@ -83,7 +113,7 @@ function daysFromNow(days) {
 Core.prototype.sync = function() {
   var c = this.cookies;
   var ttlDays = this.idExpiryDays;
-  this.id().then(function(id) {
+  return this.id().then(function(id) {
     c.set({
       name: deviceIdCookie,
       value: id,

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -46,10 +46,10 @@ describe('ravelin.core', function() {
       });
     });
 
-    it('returns IDs that expire after idExpiryDays', function() {
+    it('returns IDs that expire after cookieExpiryDays', function() {
       var r = new Ravelin({
         init: false,         // Don't persist the cookie after it expires.
-        idExpiryDays: 0.0000001 // < 10ms.
+        cookieExpiryDays: 0.0000001 // < 10ms.
       });
       return r.core.id().then(function(id) {
         expect(id).to.match(/rjs-[a-z0-9-]{30,}/);

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -4,6 +4,48 @@ describe('ravelin.core', function() {
   });
 
   describe('#id', function() {
+    it('can be configured with a string', function() {
+      var r = new Ravelin({
+        id: 'my-device-id'
+      });
+      return r.core.id().then(function(id) {
+        expect(id).to.equal('my-device-id');
+      });
+    });
+
+    it('can be configured with a Promise', function() {
+      var r = new Ravelin({
+        id: new Ravelin.Promise(function(resolve) {
+          resolve('my-device-id');
+        })
+      });
+      return r.core.id().then(function(id) {
+        expect(id).to.equal('my-device-id');
+      });
+    });
+
+    it('can be configured with a Promise that falls back to built-in IDs if empty', function() {
+      var r = new Ravelin({
+        id: new Ravelin.Promise(function(resolve) {
+          resolve('');
+        })
+      });
+      return r.core.id().then(function(id) {
+        expect(id).to.match(/rjs-[a-z0-9-]{30,}/);
+      });
+    });
+
+    it('can be configured with a Promise that falls back to built-in IDs upon errors', function() {
+      var r = new Ravelin({
+        id: new Ravelin.Promise(function(_, reject) {
+          reject('Something went wrong.');
+        })
+      });
+      return r.core.id().then(function(id) {
+        expect(id).to.match(/rjs-[a-z0-9-]{30,}/);
+      });
+    });
+
     it('returns IDs that expire after idExpiryDays', function() {
       var r = new Ravelin({
         init: false,         // Don't persist the cookie after it expires.

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -47,6 +47,8 @@ describe('ravelin.core', function() {
     });
 
     it('returns IDs that expire after cookieExpiryDays', function() {
+      // This test must happen before other Ravelin instances start persisting a
+      // cookie.
       var r = new Ravelin({
         init: false,         // Don't persist the cookie after it expires.
         cookieExpiryDays: 0.0000001 // < 10ms.
@@ -78,10 +80,19 @@ describe('ravelin.core', function() {
       });
     });
 
-    it('sets the ravelinDeviceId cookie', function() {
+    it('sets the ravelinDeviceId cookie by default', function() {
       var r = new Ravelin({});
       return r.core.id().then(function(id) {
         expect(document.cookie).to.match(new RegExp('\\bravelinDeviceId=' + id + '\\b'));
+      });
+    });
+
+    it('sets a customisable cookie', function() {
+      var r = new Ravelin({
+        cookie: 'custom-guid'
+      });
+      return r.core.id().then(function(id) {
+        expect(document.cookie).to.match(new RegExp('\\bcustom-guid=' + id + '\\b'));
       });
     });
 


### PR DESCRIPTION
Usage:

```js
new Ravelin({
	// Re-use an existing cookie, or just change the name:
	cookie: 'our-guid',

	// With a string:
	id: 'the-id',

	// Or with a Promise:
	id: new Promise(function(resolve) {
		resolve('the-id');
	}),
});
```

We fall back to the built-in device tracking if the Promise fails or resolves to an empty value.

Also:

* Export the default Promise (window.Promise || Yaku) as `Ravelin.Promise` so we can construct a Promise from tests.
* Rename `idExpiryDays` to `cookieExpiryDays.` It felt inconsistent otherwise.