### PR TITLE
testing: Better test isolation.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,6 +86,10 @@ unit tests from an integration test (piggy-backing on the browser-spawning)
 which you can run with `npm run test:integration -- --spec
 test/unit/unit.spec.js` (see below for running integration tests).
 
+Running `test/server.js` will give you an ngrok URL through which you can access
+the Mocha unit test page in any browser. Use this if you want to step through
+using a remote browser.
+
 Unit tests run in the browser and therefore must be written in IE-compatible
 JavaScript, as with code in the lib. The tests have access to:
 

--- a/test/common.js
+++ b/test/common.js
@@ -1,4 +1,26 @@
 /**
+ * isolate returns the cfg instance with a few isolating test defaults added.
+ * The ns option is for isolate only, and is not passed through to Ravelin. All
+ * other properties documented here are the defaults.
+ *
+ * @param {object} cfg
+ * @param {string} [cfg.ns=testn] A namespace added to the cookie names. Not
+ * used by this function.
+ * @param {string} [cfg.cookie=ravelinDeviceId-ns]
+ * @returns {object} The mutated cfg.
+ */
+ function isolate(cfg) {
+  if (!isolate.n) isolate.n = 0;
+  var ns = cfg.ns || 'test' + isolate.n++;
+  delete cfg.ns;
+
+  if (!('cookie' in cfg)) {
+    cfg.cookie = 'ravelinDeviceId-' + ns;
+  }
+  return cfg;
+}
+
+/**
  * done marks the test page as finished.
  */
 function done() {

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -1,81 +1,106 @@
+/* globals isolate */
+
 describe('ravelin.core', function() {
   beforeEach(function() {
     xhook.destroy();
+
+    // Delete all cookies. The tests should be fully isolated anyway, but this
+    // makes the error output cleaner.
+    var cookies = document.cookie.split(";");
+    for (var i = 0; i < cookies.length; i++) {
+      var cookie = cookies[i];
+      var eqPos = cookie.indexOf("=");
+      var name = eqPos > -1 ? cookie.substr(0, eqPos) : cookie;
+      document.cookie = name + "=;expires=Thu, 01 Jan 1970 00:00:00 GMT";
+    }
   });
 
   describe('#id', function() {
     it('can be configured with a string', function() {
-      var r = new Ravelin({
+      var r = new Ravelin(isolate({
+        cookie: 'unused',
         id: 'my-device-id'
-      });
+      }));
       return r.core.id().then(function(id) {
         expect(id).to.equal('my-device-id');
-        expect(document.cookie).to.not.match(new RegExp('\\bravelinDeviceId=my-device-id'));
+        expect(r.core.cookies.get('unused')).to.be(undefined);
       });
     });
 
     it('can be configured with a Promise', function() {
-      var r = new Ravelin({
+      var r = new Ravelin(isolate({
+        cookie: 'unused',
         id: new Ravelin.Promise(function(resolve) {
           resolve('my-device-id');
         })
-      });
+      }));
       return r.core.id().then(function(id) {
         expect(id).to.equal('my-device-id');
-        expect(document.cookie).to.not.match(new RegExp('\\bravelinDeviceId=my-device-id'));
+        expect(r.core.cookies.get('unused')).to.be(undefined);
       });
     });
 
     it('can be configured with a Promise that falls back to built-in IDs if empty', function() {
-      var r = new Ravelin({
+      var r = new Ravelin(isolate({
+        cookie: 'id-empty-promise',
         id: new Ravelin.Promise(function(resolve) {
           resolve('');
         })
-      });
+      }));
       return r.core.id().then(function(id) {
         expect(id).to.match(/rjs-[a-z0-9-]{30,}/);
-        expect(document.cookie).to.match(new RegExp('\\bravelinDeviceId='+id));
+        expect(r.core.cookies.get('id-empty-promise')).to.equal(id);
       });
     });
 
     it('can be configured with a Promise that falls back to built-in IDs upon errors', function() {
-      var r = new Ravelin({
+      var r = new Ravelin(isolate({
+        cookie: 'id-error-promise',
         id: new Ravelin.Promise(function(_, reject) {
           reject('Something went wrong.');
         })
-      });
+      }));
       return r.core.id().then(function(id) {
         expect(id).to.match(/rjs-[a-z0-9-]{30,}/);
+        expect(r.core.cookies.get('id-error-promise')).to.equal(id);
       });
     });
 
     it('returns IDs that expire after cookieExpiryDays', function() {
+      this.timeout(2500);
+      function msToDays(ms) { return ms / (86400 * 1000); }
+
       // This test must happen before other Ravelin instances start persisting a
       // cookie.
-      var r = new Ravelin({
-        init: false,         // Don't persist the cookie after it expires.
-        cookieExpiryDays: 0.0000001 // < 10ms.
-      });
+      var r = new Ravelin(isolate({
+        cookie: 'expiredDeviceId',
+        syncMs: 10000,
+
+        // Expiry times are formatted with second granularity, so it's hard to
+        // make this quicker. Is it safe to change?
+        cookieExpiryDays: msToDays(1500)
+      }));
       return r.core.id().then(function(id) {
         expect(id).to.match(/rjs-[a-z0-9-]{30,}/);
+        expect(r.core.cookies.get('expiredDeviceId')).to.be(id);
 
         return new r.core.Promise(function(resolve) {
-          setTimeout(resolve, 100);
+          setTimeout(resolve, 2000);
         }).then(function() {
-          expect(document.cookie).to.not.match(new RegExp('\\bravelinDeviceId='));
+          expect(r.core.cookies.get('expiredDeviceId')).to.be(undefined);
         });
       });
     });
 
     it('returns IDs', function() {
-      var r = new Ravelin({});
+      var r = new Ravelin(isolate({}));
       return r.core.id().then(function(id) {
         expect(id).to.match(/rjs-[a-z0-9-]{30,}/);
       });
     });
 
     it('keeps returning the same ID', function() {
-      var r = new Ravelin({});
+      var r = new Ravelin(isolate({}));
       return r.core.id().then(function(id1) {
         return r.core.id().then(function(id2) {
           expect(id1).to.eql(id2);
@@ -84,44 +109,45 @@ describe('ravelin.core', function() {
     });
 
     it('sets the ravelinDeviceId cookie by default', function() {
-      var r = new Ravelin({});
+      var r = new Ravelin(isolate({
+        cookie: 'ravelinDeviceId'
+      }));
       return r.core.id().then(function(id) {
         expect(document.cookie).to.match(new RegExp('\\bravelinDeviceId=' + id + '\\b'));
+        expect(r.core.cookies.get('ravelinDeviceId')).to.be(id); // Test our cookie getter works!
       });
     });
 
     it('sets a customisable cookie', function() {
-      var r = new Ravelin({
+      var r = new Ravelin(isolate({
         cookie: 'custom-guid'
-      });
+      }));
       return r.core.id().then(function(id) {
         expect(document.cookie).to.match(new RegExp('\\bcustom-guid=' + id + '\\b'));
       });
     });
 
     it('reinstates an ID removed from cookies', function() {
-      var r1 = new Ravelin({
-        syncMs: 5
+      var cfg = isolate({
+        cookie: 'removed-cookie',
+        syncMs: 10
       });
+      var r1 = new Ravelin(cfg);
       return r1.core.id().then(function(id1) {
-        // Take the ID out of the cookies. This is the only time that we should
-        // clear the cookies, because there may have been other Ravelin
-        // instances created that are attempting to restore their deviceId in
-        // the cookies.
-        // TODO: Can we r.core._stop()?
-        var cookies = document.cookie.split(";");
-        for (var i = 0; i < cookies.length; i++) {
-            var cookie = cookies[i];
-            var eqPos = cookie.indexOf("=");
-            var name = eqPos > -1 ? cookie.substr(0, eqPos) : cookie;
-            document.cookie = name + "=;expires=Thu, 01 Jan 1970 00:00:00 GMT";
-        }
+        // Remove the cookie.
+        r1.core.cookies.set({
+          name: 'removed-cookie',
+          value: 'unset',
+          expires: new Date(new Date().getTime() - 10000)
+        });
+        expect(r1.core.cookies.get('removed-cookie')).to.be(undefined);
+        expect(document.cookie).to.not.match(/\bremoved-cookie=\b/);
 
-        // Wait a second.
-        return new r1.core.Promise(function(resolve) {
+        // Wait for the sync to reoccur..
+        return new Ravelin.Promise(function(resolve) {
           setTimeout(resolve, 300);
         }).then(function() {
-          var r2 = new Ravelin({});
+          var r2 = new Ravelin(cfg);
           return r2.core.id().then(function(id2) {
             expect(id1).to.eql(id2);
           });
@@ -141,11 +167,11 @@ describe('ravelin.core', function() {
         xhook.before(function(r) {
           return {status: 204};
         });
-        var r = new Ravelin({
+        var r = new Ravelin(isolate({
           init: false,
           key: test.key,
           api: test.api
-        });
+        }));
         expect(r.core.api).to.be(test.expApi);
       });
     });
@@ -159,10 +185,10 @@ describe('ravelin.core', function() {
       {key: 'publishable_key_test_env_123', expApi: 'https://env.ravelin.click'}
     ]).each(function(n, test) {
       it('infers url from key in test = ' + JSON.stringify(test), function() {
-        var r = new Ravelin({
+        var r = new Ravelin(isolate({
           key: test.key,
           api: test.api
-        });
+        }));
         expect(r.core.api).to.be(test.expApi);
       });
     });
@@ -175,7 +201,7 @@ describe('ravelin.core', function() {
       b.b = b;
 
       // Try to serialise b in a request.
-      var r = new Ravelin({key: 'k', api: '/'});
+      var r = new Ravelin(isolate({key: 'k', api: '/'}));
       try {
         return r.core.send('POST', 'z', b)
           .then(
@@ -195,7 +221,7 @@ describe('ravelin.core', function() {
       xhook.before(function(r) {
         throw new Error('not retried');
       });
-      var r = new Ravelin({key: 'k', api: '/'});
+      var r = new Ravelin(isolate({key: 'k', api: '/'}));
       return r.core.send('POST', 'z', {}).
         then(
           function pass(r) {
@@ -217,10 +243,10 @@ describe('ravelin.core', function() {
         }
         return {status: 204};
       });
-      var rav = new Ravelin({
+      var rav = new Ravelin(isolate({
         api: '/',
         key: 'retries'
-      });
+      }));
       return rav.core.send('POST', 'z', {
         retryTest: 'hello'
       }).then(function(r) {
@@ -236,10 +262,10 @@ describe('ravelin.core', function() {
       xhook.before(function(req) {
         return {status: 500};
       });
-      var rav = new Ravelin({
+      var rav = new Ravelin(isolate({
         api: '/',
         key: 'retries'
-      });
+      }));
       return rav.core.send('POST', 'z', {
         retryTest: 'hello'
       }).then(

--- a/test/track.test.js
+++ b/test/track.test.js
@@ -1,3 +1,5 @@
+/* globals isolate */
+
 describe('ravelin.track', function() {
   var r;
 
@@ -29,7 +31,7 @@ describe('ravelin.track', function() {
         }).then(done, done);
         return {status: 204};
       });
-      r = new Ravelin({key: key, api: '/'});
+      r = new Ravelin(isolate({key: key, api: '/'}));
     });
   });
 
@@ -49,7 +51,7 @@ describe('ravelin.track', function() {
         }).then(done, done);
         return {status: 204};
       });
-      r = new Ravelin({key: key, api: '/', init: false});
+      r = new Ravelin(isolate({key: key, api: '/', init: false}));
       r.track.event('custom-event');
     });
 
@@ -68,7 +70,7 @@ describe('ravelin.track', function() {
         }).then(done, done);
         return {status: 204};
       });
-      r = new Ravelin({key: key, api: '/', init: false});
+      r = new Ravelin(isolate({key: key, api: '/', init: false}));
       r.track.event('custom-event', {extra: true});
     });
   });
@@ -205,7 +207,7 @@ describe('ravelin.track', function() {
           return {status: 204};
         });
 
-        r = new Ravelin({key: key, api: '/'});
+        r = new Ravelin(isolate({key: key, api: '/'}));
 
         var input = $(test.into).appendTo(document.body);
         input = input.find('input')[0] || input[0];
@@ -244,7 +246,7 @@ describe('ravelin.track', function() {
         return {status: 204};
       });
 
-      r = new Ravelin({key: key, api: '/'});
+      r = new Ravelin(isolate({key: key, api: '/'}));
 
       var input = $('<form action=/ name="form-name"><input name=hello data-rvn-sensitive=true></form>')
         .appendTo(document.body)
@@ -283,7 +285,7 @@ describe('ravelin.track', function() {
         return {status: 204};
       });
 
-      r = new Ravelin({key: key, api: '/'});
+      r = new Ravelin(isolate({key: key, api: '/'}));
 
       var input = $('<form action=/ name="form-name"><input type=password name=action></form>')
         .appendTo(document.body)

--- a/test/unit/index.html
+++ b/test/unit/index.html
@@ -22,7 +22,6 @@
     <script src="../ravelin.js"></script>
     <script src="../common.js"></script>
 
-    <script src="../all.test.js"></script>
     <script src="../core.test.js"></script>
     <script src="../encrypt.test.js"></script>
     <script src="../track.test.js"></script>


### PR DESCRIPTION
Introduces a new `isolate` helper function that will set the default cookie names to incrementing values so that the tests don't bump into each other. Also better confirm that the use of the `id` constructor option doesn't set ravelinDeviceId cookies.