### PR TITLE
Move Session IDs into Core

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -40,18 +40,25 @@ export function Core(cfg) {
     domain: cfg.cookieDomain
   });
 
-  if (cfg.id && cfg.id.then) {
-    this._id = cfg.id;
-  } else {
-    var id = cfg.id;
-    this._id = new this.Promise(function(r) {
-      r(id);
-    });
-  }
+  this._id = resolve(this.Promise, cfg.id);
   this.sync();
   if (cfg.init !== false) {
     this.attach(cfg.syncMs || 2000);
   }
+}
+
+/**
+ * resolve returns a Promise that resolves to v. If v is already a promise, we
+ * just return it.
+ * @param {PromiseConstructor} Promise The promise implementation.
+ * @param {Promise|any} v The value we want in a then.
+ * @returns {Promise}
+ */
+function resolve(Promise, v) {
+  if (v && typeof(v.then) === 'function') {
+    return v;
+  }
+  return new Promise(function(r) { r(v); });
 }
 
 /**

--- a/lib/core.js
+++ b/lib/core.js
@@ -229,7 +229,9 @@ var _XDomainRequest = window.XDomainRequest;
 Core.prototype.reportError = function(e) {
   var that = this;
   if (this._ids) {
-    return this._ids.then(report, function() { report(); });
+    return this._ids
+      .then(undefined, function() { /* swallow error. */ })
+      .then(report);
   }
   return report();
 

--- a/lib/core.js
+++ b/lib/core.js
@@ -90,12 +90,11 @@ Core.prototype.ids = function() {
   this._ids =
     this.sniffError(this._id)
     .then(undefined, function() { /* swallow error. */ })
-    .then(function(d) {
-      var explicit = !!d;
-      if (!d) d = c.cookies.get(c.cookie);
+    .then(function(cfgId) {
+      var d = cfgId || c.cookies.get(c.cookie);
       var s = c.cookies.get(c.sessionCookie);
 
-      if (!explicit && s) {
+      if (!cfgId && s) {
         // Restore d from s.
         var sep = s.indexOf(':');
         if (sep != -1) {

--- a/lib/core.js
+++ b/lib/core.js
@@ -13,8 +13,8 @@ import { promiseRetry, bind, uuid } from './util';
  * @prop {string} [api] A string of the format "https://api.ravelin.net" which forms the base of API requests.
  * @prop {string|Promise<string>} [id] An explicit deviceId to use. If the Promise errors or returns an empty value, Ravelin's own deviceId tracking kicks in.
  * @prop {string} [cookie=ravelinDeviceId] The name of the cookie that the deviceId is kept in.
- * @prop {string} [cookieDomain] The domain on which to set cookies. Ignored if invalid.
- * @prop {number} [cookieExpiryDays=365] The max lifetime of a deviceId, in days.
+ * @prop {string} [cookieDomain] The domain on which to set cookies.
+ * @prop {number} [cookieExpiryDays=365] The max lifetime of a deviceId, in days. Values <= 0 makes Ravelin treat the named cookie as read-only.
  * @prop {number} [syncMs=2000] The sync timeout frequency.
  * @prop {number} [sendRetryMs=150] The send retry backoff time.
  * @prop {PromiseConstructor} [Promise] The Promise implementation to use in ravelinjs's asynchronous functions.
@@ -34,74 +34,90 @@ export function Core(cfg) {
   this.api = this.api[0] + this.api.substr(1).replace(/^\/+|\/$/g, '');
   this.sendRetryMs = cfg.sendRetryMs || 150;
   this.cookie = cfg.cookie || 'ravelinDeviceId';
+  this.sessionCookie = cfg.sessionCookie || 'ravelinSessionId';
   this.cookieExpiryDays = cfg.cookieExpiryDays || 365;
   this.cookies = new CookieJar({
     domain: cfg.cookieDomain
   });
 
-  if (cfg.id) {
-    this._id = this._idBackup(cfg.id);
+  if (cfg.id && cfg.id.then) {
+    this._id = cfg.id;
   } else {
-    this.sync();
-    if (cfg.init !== false) {
-      this.attach(cfg.syncMs || 2000);
-    }
+    var id = cfg.id;
+    this._id = new this.Promise(function(r) {
+      r(id);
+    });
+  }
+  this.sync();
+  if (cfg.init !== false) {
+    this.attach(cfg.syncMs || 2000);
   }
 }
 
 /**
- * _idBackup wraps the user-given id, providing error reporting and a non-empty
- * fallback in-case it errors or provides an empty value.
- * @param {string|Promise<string>} id
- * @returns {Promise<string>}
- */
-Core.prototype._idBackup = function(id) {
-  var that = this;
-  function backup() {
-    that._id = null;
-    that.sync();
-    return that.id();
-  }
-
-  // We could have handled id the same way - whether string or Promise - if new
-  // Promise(r => r(id)).then(sid => ...) always resolved to a string sid, but
-  // the Yaku Promise implementation we bundle doesn't unwrap the Promise id
-  // resolved in the constructor. So instead, we look for something then-able.
-  if (!id.then) {
-    return new this.Promise(function(r) { r(id); });
-  }
-
-  // Wrap the Promise id to ensure we never get an empty deviceId.
-  return this.sniffError(function() {
-    return id;
-  }).then(
-    function(id) {
-      if (id) return id;
-      return backup();
-    },
-    backup
-  );
-};
-
-/**
- * id reads our device identity from the browser.
- * @fulfil {string} The device ID.
+ * id reads our device ID from the browser.
  * @returns {Promise<string>}
  */
 Core.prototype.id = function() {
-  if (this._id) {
-    // Keep the IDs from last time.
-    return this._id;
+  return this.ids().then(function(ids) {
+    return ids.device;
+  });
+};
+
+/**
+ * @typedef {Object} IDs
+ * @prop {string} device
+ * @prop {string} session
+ */
+
+/**
+ * ids reads all IDs from the browser.
+ * @returns {Promise<IDs>}
+ */
+Core.prototype.ids = function() {
+  if (this._ids) {
+    return this._ids;
   }
 
   var c = this;
-  this._id = this.sniffError(function() {
-    return new c.Promise(function(resolve) {
-      resolve(c.cookies.get(c.cookie) || 'rjs-' + uuid());
+  this._ids =
+    this.sniffError(this._id)
+    .then(undefined, function() { /* swallow error. */ })
+    .then(function(d) {
+      var explicit = !!d;
+      if (!d) d = c.cookies.get(c.cookie);
+      var s = c.cookies.get(c.sessionCookie);
+
+      if (!explicit && s) {
+        // Restore d from s.
+        var sep = s.indexOf(':');
+        if (sep != -1) {
+          d = s.substr(0, sep);
+        }
+
+        // Strip d: from the beginning of s.
+        if (d && hasPrefix(s, d+':')) {
+          s = s.substr(d.length+1);
+        }
+      }
+
+      return {
+        device: d || 'rjs-' + uuid(),
+        session: s || uuid()
+      };
     });
-  });
-  return this._id;
+  return this._ids;
 };
+
+/**
+ * hasPrefix returns whether string s starts with string prefix.
+ * @param {string} s
+ * @param {string} prefix
+ * @returns {boolean}
+ */
+function hasPrefix(s, prefix) {
+  return s.substr(0, prefix.length) === prefix;
+}
 
 /**
  * daysFromNow returns the current time, days in the future.
@@ -117,12 +133,17 @@ function daysFromNow(days) {
  */
 Core.prototype.sync = function() {
   var c = this;
-  var ttlDays = this.cookieExpiryDays;
-  return this.id().then(function(id) {
+  return this.ids().then(function(ids) {
+    if (c.cookieExpiryDays > 0) {
+      c.cookies.set({
+        name: c.cookie,
+        value: ids.device,
+        expires: daysFromNow(c.cookieExpiryDays)
+      });
+    }
     c.cookies.set({
-      name: c.cookie,
-      value: id,
-      expires: daysFromNow(ttlDays)
+      name: c.sessionCookie,
+      value: ids.device + ":" + ids.session
     });
   });
 };
@@ -201,14 +222,14 @@ var _XDomainRequest = window.XDomainRequest;
  */
 Core.prototype.reportError = function(e) {
   var that = this;
-  if (this._id) {
-    return this.id().then(report);
+  if (this._ids) {
+    return this._ids.then(report, function() { report(); });
   }
   return report();
 
-  function report(id) {
+  function report(ids) {
     return that.send('POST', 'z/err', {
-      deviceId: id,
+      deviceId: ids && ids.device,
       libVer: version,
       type: e.name,
       msg: e.message || e,
@@ -224,7 +245,7 @@ Core.prototype.reportError = function(e) {
 Core.prototype.sniffError = function(fn) {
   var c = this;
   try {
-    var p = fn();
+    var p = typeof fn === 'function' ? fn() : fn;
     if (p && p.then) p.then(undefined, function(e) {
       c.reportError(e);
     });

--- a/lib/track.js
+++ b/lib/track.js
@@ -16,15 +16,6 @@ export function Track(core, cfg) {
 
   /** @prop {string} windowId An identifier which lasts until the next page refresh. */
   this.windowId = uuid();
-  /** @prop {string} sessionId An identifier which lasts until this website is closed. */
-  this.sessionId = core.cookies.get('ravelinSessionId');
-  if (!this.sessionId) {
-    this.sessionId = uuid();
-    core.cookies.set({
-      name: 'ravelinSessionId',
-      value: this.sessionId
-    });
-  }
 
   this.dimensions = windowDimensions();
 
@@ -114,7 +105,7 @@ Track.prototype._detach = function() {
  */
 Track.prototype._send = function(type, name, props) {
   var that = this;
-  return this.core.id().then(function(deviceId) {
+  return this.core.ids().then(function(ids) {
     return that.core.send('POST', '/z', {events: [{
       eventType: type,
       eventData: {
@@ -126,8 +117,8 @@ Track.prototype._send = function(type, name, props) {
       eventMeta: {
         trackingSource: 'browser',
         url: window.location.href,
-        ravelinDeviceId: deviceId,
-        ravelinSessionId: that.sessionId,
+        ravelinDeviceId: ids.device,
+        ravelinSessionId: ids.session,
         ravelinWindowId: that.windowId,
         pageTitle: document.title,
         referrer: document.referrer || undefined,

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -33,15 +33,9 @@ var plugins = [
   }),
 ];
 
-glob.sync("lib/bundle/*.js").forEach(bundle => builds.push(
-  {
-    input: bundle,
-    output: {
-      file: 'build/ravelin-' + basename(bundle),
-      ...output,
-    },
-    plugins: plugins,
-  },
+glob.sync("lib/bundle/*.js")
+.sort((a, b) => b.length - a.length)
+.forEach(bundle => builds.push(
   {
     input: bundle,
     output: {
@@ -57,5 +51,13 @@ glob.sync("lib/bundle/*.js").forEach(bundle => builds.push(
         safari10: true,
       }),
     ]),
+  },
+  {
+    input: bundle,
+    output: {
+      file: 'build/ravelin-' + basename(bundle),
+      ...output,
+    },
+    plugins: plugins,
   },
 ));

--- a/test/common.js
+++ b/test/common.js
@@ -18,6 +18,9 @@
   if (!('cookie' in cfg)) {
     cfg.cookie = 'ravelinDeviceId-' + ns;
   }
+  if (!('sessionCookie' in cfg)) {
+    cfg.sessionCookie = 'ravelinSessionId-' + ns;
+  }
   if (!('syncMs' in cfg)) {
     cfg.syncMs = 30000;
   }

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -260,7 +260,7 @@ describe('ravelin.core', function() {
     });
 
     it('returns IDs that expire after cookieExpiryDays', function() {
-      this.timeout(2500);
+      this.timeout(4000);
       function msToDays(ms) { return ms / (86400 * 1000); }
 
       // This test must happen before other Ravelin instances start persisting a

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -190,9 +190,7 @@ describe('ravelin.core', function() {
           expect(ids.device).to.match(t.exp.device);
           expect(ids.session).to.match(t.exp.session);
           expect(r.core.cookies.get(cfg.sessionCookie)).to.be(ids.device + ':' + ids.session);
-          if (!(cfg.cookieExpiryDays <= 0)) {
-            expect(r.core.cookies.get(cfg.cookie)).to.be(ids.device);
-          }
+          expect(r.core.cookies.get(cfg.cookie)).to.be(ids.device);
         });
       });
     });

--- a/test/track.test.js
+++ b/test/track.test.js
@@ -21,13 +21,14 @@ describe('ravelin.track', function() {
       xhook.before(function(req) {
         if (!keysMatch(req, key)) return {status: 204};
 
-        r.core.id().then(function(deviceId) {
+        r.core.ids().then(function(ids) {
           var loadEvent = JSON.parse(req.body).events[0];
           expect(loadEvent).to.have.property('eventType', 'track');
           expect(loadEvent).to.have.property('libVer', '1.2.0-ravelinjs');
           expect(loadEvent.eventData).to.eql({eventName: 'PAGE_LOADED'});
           expect(loadEvent.eventMeta.trackingSource).to.be('browser');
-          expect(loadEvent.eventMeta.ravelinDeviceId).to.be(deviceId);
+          expect(loadEvent.eventMeta.ravelinDeviceId).to.be(ids.device);
+          expect(loadEvent.eventMeta.ravelinSessionId).to.be(ids.session);
         }).then(done, done);
         return {status: 204};
       });
@@ -41,13 +42,14 @@ describe('ravelin.track', function() {
       xhook.before(function(req) {
         if (!keysMatch(req, key)) return {status: 204};
 
-        r.core.id().then(function(deviceId) {
+        r.core.ids().then(function(ids) {
           var e = JSON.parse(req.body).events[0];
           expect(e).to.have.property('eventType', 'track');
           expect(e).to.have.property('libVer', '1.2.0-ravelinjs');
           expect(e.eventData).to.eql({eventName: 'custom-event'});
           expect(e.eventMeta.trackingSource).to.be('browser');
-          expect(e.eventMeta.ravelinDeviceId).to.be(deviceId);
+          expect(e.eventMeta.ravelinDeviceId).to.be(ids.device);
+          expect(e.eventMeta.ravelinSessionId).to.be(ids.session);
         }).then(done, done);
         return {status: 204};
       });
@@ -60,13 +62,14 @@ describe('ravelin.track', function() {
       xhook.before(function(req) {
         if (!keysMatch(req, key)) return {status: 204};
 
-        r.core.id().then(function(deviceId) {
+        r.core.ids().then(function(ids) {
           var e = JSON.parse(req.body).events[0];
           expect(e).to.have.property('eventType', 'track');
           expect(e).to.have.property('libVer', '1.2.0-ravelinjs');
           expect(e.eventData).to.eql({eventName: 'custom-event', properties: {extra: true}});
           expect(e.eventMeta.trackingSource).to.be('browser');
-          expect(e.eventMeta.ravelinDeviceId).to.be(deviceId);
+          expect(e.eventMeta.ravelinDeviceId).to.be(ids.device);
+          expect(e.eventMeta.ravelinSessionId).to.be(ids.session);
         }).then(done, done);
         return {status: 204};
       });
@@ -193,12 +196,13 @@ describe('ravelin.track', function() {
           }
 
           // Validate the event.
-          r.core.id().then(function(deviceId) {
+          r.core.ids().then(function(ids) {
             event = event.events[0];
             expect(event).to.have.property('eventType', 'paste');
             expect(event).to.have.property('libVer', '1.2.0-ravelinjs');
             expect(event.eventMeta.trackingSource).to.be('browser');
-            expect(event.eventMeta.ravelinDeviceId).to.be(deviceId);
+            expect(event.eventMeta.ravelinDeviceId).to.be(ids.device);
+            expect(event.eventMeta.ravelinSessionId).to.be(ids.session);
             expect(event.eventData).to.eql({
               eventName: 'paste',
               properties: test.props
@@ -228,12 +232,13 @@ describe('ravelin.track', function() {
         }
 
         // Validate the event.
-        r.core.id().then(function(deviceId) {
+        r.core.ids().then(function(ids) {
           event = event.events[0];
           expect(event).to.have.property('eventType', 'paste');
           expect(event).to.have.property('libVer', '1.2.0-ravelinjs');
           expect(event.eventMeta.trackingSource).to.be('browser');
-          expect(event.eventMeta.ravelinDeviceId).to.be(deviceId);
+          expect(event.eventMeta.ravelinDeviceId).to.be(ids.device);
+          expect(event.eventMeta.ravelinSessionId).to.be(ids.session);
           expect(event.eventData).to.eql({
             eventName: 'paste',
             properties: {
@@ -267,12 +272,13 @@ describe('ravelin.track', function() {
         }
 
         // Validate the event.
-        r.core.id().then(function(deviceId) {
+        r.core.ids().then(function(ids) {
           event = event.events[0];
           expect(event).to.have.property('eventType', 'paste');
           expect(event).to.have.property('libVer', '1.2.0-ravelinjs');
           expect(event.eventMeta.trackingSource).to.be('browser');
-          expect(event.eventMeta.ravelinDeviceId).to.be(deviceId);
+          expect(event.eventMeta.ravelinDeviceId).to.be(ids.device);
+          expect(event.eventMeta.ravelinSessionId).to.be(ids.session);
           expect(event.eventData).to.eql({
             eventName: 'paste',
             properties: {

--- a/test/track/track.spec.js
+++ b/test/track/track.spec.js
@@ -29,7 +29,7 @@ describe('ravelin.track', function () {
   it('sends page-load events', function () {
     // Read the device and session IDs from the cookies.
     const cookies = browser.getCookies();
-    sessionId = cookies.filter(({ name }) => name === 'ravelinSessionId')[0].value;
+    sessionId = cookies.filter(({ name }) => name === 'ravelinSessionId')[0].value.replace(/^.+?:/, '');
     deviceId = cookies.filter(({ name }) => name === 'ravelinDeviceId')[0].value;
     if (!deviceId.match(/^rjs-/)) {
       throw new Error('Expected cookie ravelinDeviceId to start with "rjs-" but got ' + deviceId);


### PR DESCRIPTION
It's looking like having a ravelinSessionId in core is going to be quite useful. Seems Browsers love hanging onto these. There's a new `sessionCookie` constructor option, and `ids():Promise<{device: String, session: String}>` method but I don't think either require public documentation.

Perhaps if we craft a v2 release we can rename these cookies to something shorter :thinking: 