### PR TITLE
track: Bail on FireFox "can't access dead objects"

### DIFF
--- a/lib/track.js
+++ b/lib/track.js
@@ -17,7 +17,9 @@ export function Track(core, cfg) {
   /** @prop {string} windowId An identifier which lasts until the next page refresh. */
   this.windowId = uuid();
 
-  this.dimensions = windowDimensions();
+  try {
+    this.dimensions = windowDimensions();
+  } catch(e) {}
 
   // Start tracking events.
   if (cfg.init !== false) {
@@ -149,9 +151,15 @@ Track.prototype.event = function(name, props) {
  * resize event handler.
  */
 Track.prototype.resize = function() {
+  var cur;
+  try {
+    cur = windowDimensions();
+  } catch (e) {
+    return;
+  }
+
   // Swap out old sizes.
   var old = this.dimensions;
-  var cur = windowDimensions();
   this.dimensions = cur;
 
   if (old.w === cur.w && old.h === cur.h) {
@@ -169,6 +177,16 @@ Track.prototype.resize = function() {
   });
 };
 
+/**
+ * windowDimensions returns the size of the browser window, using the first set
+ * of properties available to do so.
+ *
+ * There is a strange behaviour on Firefox (possibly related to extensions?)
+ * where this function can throw a "TypeError: can't access dead object" -
+ * https://github.com/unravelin/ravelinjs/issues/105.
+ *
+ * @returns {w:Number, h:Number}
+ */
 function windowDimensions() {
   return {
     w: window.outerWidth || window.innerWidth || document.documentElement.clientWidth || document.body.clientWidth,


### PR DESCRIPTION
Silence, rather than fix the problem. From what I've read about this error, the window must be closed for this exception to occur.

closes #105