### PR TITLE
Ngrok auth token

### DIFF
--- a/test/server.js
+++ b/test/server.js
@@ -112,11 +112,12 @@ async function launchProxy(app) {
 
   // Spin up an ngrok tunnel pointing to our app.
   return ngrok.connect({
+    authtoken: process.env.NGROK_AUTH_TOKEN,
     addr: local.port,
     onStatusChange: function(status) {
       // Shut down the express app when ngrok is closed.
       if (status == 'closed') listener.close();
-    },
+    }
   }).then(url => ({
     internal: `http://${local.address}:${local.port}`,
     internalPort: local.port,


### PR DESCRIPTION
## Description 
Provide an auth token for ngrok. 
This fixes issues with `send` integration tests. Since ngrok now requires users to sign into an account in order to start the tunnel, all `Remote URL` send test requests were failing. 