### PR TITLE
Options to disable +track initialisation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: cimg/node:10
+      - image: cimg/node:10.24
 
     working_directory: ~/repo
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/node:10
+      - image: cimg/node:10
 
     working_directory: ~/repo
 

--- a/.jshintrc
+++ b/.jshintrc
@@ -8,7 +8,8 @@
   "undef": true,
   "browser": true,
   "globals": {
-    "JSON": true
+    "JSON": true,
+    "RAVELINJS_VERSION": true
   },
 
   "overrides": {

--- a/README.md
+++ b/README.md
@@ -229,8 +229,9 @@ var rav = new Ravelin({
      */
     // rsaKey: '0|...',
     /**
-     * @prop {Object} [page] Additional properties to describe the initial page
-     * load event. Must be JSON-encodable.
+     * @prop {Object|Boolean} [page] Additional properties to describe the
+     * initial page load event. If false, suppresses the initial page-load event.
+     * Must be JSON-encodable.
      */
     // page: {section: 'about'}
     /**

--- a/lib/core.js
+++ b/lib/core.js
@@ -3,7 +3,6 @@
  * other modules to communicate with the Ravelin API.
  */
 
-import version from './version';
 import { CookieJar } from './cookies';
 import { promiseRetry, bind, uuid } from './util';
 
@@ -29,6 +28,7 @@ export function Core(cfg) {
   this.Promise = cfg.Promise;
 
   // API connectivity.
+  this.version = cfg.version || RAVELINJS_VERSION;
   this.key = cfg.key;
   this.api = cfg.api || apiFromKey(this.key);
   this.api = this.api[0] + this.api.substr(1).replace(/^\/+|\/$/g, '');
@@ -238,7 +238,7 @@ Core.prototype.reportError = function(e) {
   function report(ids) {
     return that.send('POST', 'z/err', {
       deviceId: ids && ids.device,
-      libVer: version,
+      libVer: that.version,
       type: e.name,
       msg: e.message || e,
       error: e.stack

--- a/lib/encrypt.js
+++ b/lib/encrypt.js
@@ -3,7 +3,6 @@
  */
 
 import {sjcl, RSAKey} from './encryption-vendored';
-import version from './version';
 
 /**
  * @typedef {object} Card
@@ -139,7 +138,7 @@ Encrypt.prototype.card = function(card) {
     cardCiphertext: aesResult.ciphertextB64,
     aesKeyCiphertext: rsaResultB64,
     algorithm: 'RSA_WITH_AES_256_GCM',
-    ravelinSDKVersion: version,
+    ravelinSDKVersion: this.core.version,
     keyIndex: key.index,
     keySignature: key.sig
   };

--- a/lib/track.js
+++ b/lib/track.js
@@ -25,7 +25,7 @@ export function Track(core, cfg) {
   } catch(e) {}
 
   // Start tracking events.
-  if (cfg.init !== false) {
+  if (cfg.init !== false && cfg.track !== false) {
     if (cfg.page !== false) {
       this.load(cfg.page);
     }

--- a/lib/track.js
+++ b/lib/track.js
@@ -2,8 +2,10 @@ import { uuid } from "./util";
 
 /**
  * @typedef {object} TrackConfig
- * @prop {boolean} [init=true] Whether to hook into the browser.
- * @prop {Object} page Additional properties describing the page, passed to load(page).
+ * @prop {boolean} [init=true] False disables hooking into the browser.
+ * @prop {boolean} [track=true] False disables hooking into the browser.
+ * @prop {Object|boolean} [page] Additional properties describing the page,
+ * passed to load(page). If false, disables automatic page tracking.
  */
 
 /**

--- a/lib/track.js
+++ b/lib/track.js
@@ -27,7 +27,9 @@ export function Track(core, cfg) {
 
   // Start tracking events.
   if (cfg.init !== false) {
-    this.load(cfg.page);
+    if (cfg.page !== false) {
+      this.load(cfg.page);
+    }
     this._attachAll();
   }
 }

--- a/lib/track.js
+++ b/lib/track.js
@@ -28,12 +28,21 @@ export function Track(core, cfg) {
 
   // Start tracking events.
   if (cfg.init !== false && cfg.track !== false) {
-    if (cfg.page !== false) {
-      this.load(cfg.page);
-    }
-    this._attachAll();
+    this.init(cfg.page);
   }
 }
+
+/**
+ * init hooks Track into the page.
+ * @param {Object|boolean} page Additional properties describing the page,
+ * passed to load(page). If false, disables automatic page tracking.
+ */
+Track.prototype.init = function(page) {
+  if (page !== false) {
+    this.load(page);
+  }
+  this._attachAll();
+};
 
 /**
  * _attachAll event listeners at the root of the document to return some key

--- a/lib/track.js
+++ b/lib/track.js
@@ -1,5 +1,4 @@
 import { uuid } from "./util";
-import version from "./version";
 
 /**
  * @typedef {object} TrackConfig
@@ -120,7 +119,7 @@ Track.prototype._send = function(type, name, props) {
         properties: props
       },
 
-      libVer: version,
+      libVer: that.core.version,
       eventMeta: {
         trackingSource: 'browser',
         url: window.location.href,

--- a/lib/version.js
+++ b/lib/version.js
@@ -1,3 +1,0 @@
-/* jshint undef: false */
-// Substituted by rollup's replace().
-export default RAVELINJS_VERSION;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ravelinjs",
-  "version": "1.5.0",
+  "version": "1.6.0-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ravelinjs",
-  "version": "1.6.0-1",
+  "version": "1.6.0-2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ravelinjs",
-  "version": "1.6.0-0",
+  "version": "1.6.0-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ravelinjs",
-  "version": "1.6.0-0",
+  "version": "1.6.0-1",
   "license": "Apache-2.0",
   "description": "Ravelin's Browser SDK",
   "author": "Ravelin (https://github.com/unravelin) <support@ravelin.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ravelinjs",
-  "version": "1.6.0-1",
+  "version": "1.6.0-2",
   "license": "Apache-2.0",
   "description": "Ravelin's Browser SDK",
   "author": "Ravelin (https://github.com/unravelin) <support@ravelin.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ravelinjs",
-  "version": "1.5.0",
+  "version": "1.6.0-0",
   "license": "Apache-2.0",
   "description": "Ravelin's Browser SDK",
   "author": "Ravelin (https://github.com/unravelin) <support@ravelin.com>",

--- a/test/track.test.js
+++ b/test/track.test.js
@@ -55,6 +55,19 @@ describe('ravelin.track', function() {
       r = new Ravelin(isolate({key: key, api: '/', page: {section: 'test'}}));
     });
 
+    it('is suppressed by page: false', function(done) {
+      var key = this.test.fullTitle();
+      var errored = false;
+      xhook.before(function(req) {
+        if (!keysMatch(req, key)) return {status: 204};
+        errored = true;
+        done('received an API request but should have gotten none: ' + JSON.stringify(req));
+        return {status: 204};
+      });
+      setTimeout(function() { if (!errored) done(); }, 200);
+      r = new Ravelin(isolate({key: key, api: '/', page: false}));
+    });
+
     it('sends custom fields', function(done) {
       var key = this.test.fullTitle();
       xhook.before(function(req) {
@@ -420,8 +433,8 @@ describe('ravelin.track', function() {
       });
 
       r = new Ravelin(isolate({
-        key: key, 
-        api: '/', 
+        key: key,
+        api: '/',
         classifyPaste: function(e) {
           return {
             sensitive: e.target.hasAttribute('sensitive-data')

--- a/test/wdio.conf.js
+++ b/test/wdio.conf.js
@@ -295,7 +295,7 @@ exports.config = {
   baseUrl: baseUrl,
 
   // Default timeout for all waitFor* commands.
-  waitforTimeout: 10000,
+  waitforTimeout: 13000,
 
   // Default timeout in milliseconds for request
   // if browser driver or grid doesn't send response


### PR DESCRIPTION
With the goal of providing a backwards-compatible shim for the old JavaScript, we want to support lazily-invoking the page-load event and event tracking more generally. To this end, the +track bundle now supports

* the initialisation option `track: false` to delay the sending of page-load events or adding event handlers, after which `r.track.init(page)` can be called to add event handlers and send the page-load event; and
* the initialisatino option `page: false` to delay the sending of page-load events, after which `r.track.load(page)` can be called to send the page-load event.

So that the shim library wrapping ravelinjs v1 can inject its own version on events, we now also support the initialisation option `version` (e.g. `r = new Ravelin({version: "1.6.0-rvnjs"})` to override the version number sent back to the library.