### PR TITLE
Remove sourcemaps from build and dist.

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -10,7 +10,6 @@ var builds = module.exports = [];
 
 var output = {
   format: 'iife',
-  sourcemap: true,
   name: 'Ravelin',
   esModule: false,
 
@@ -29,7 +28,6 @@ var plugins = [
   resolve(),
   commonjs(),
   license({
-    sourcemap: true,
     banner: `/*! <%= pkg.name %> <%= pkg.version %> - https://github.com/unravelin/ravelinjs. Copyright <%= moment().format('YYYY') %> */`,
   }),
 ];


### PR DESCRIPTION
Including the sourcemap URL is creating 404s when the minified library is copied onto other hosts without the sourcemap. That's the most common use-case, so lets remove the sourcemap.