### PR TITLE
ci: Manually upload artefacts to Google Cloud Storage (GCS) with gsutil

### DIFF
--- a/.cloudbuild/e2e.yaml
+++ b/.cloudbuild/e2e.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://json.schemastore.org/cloudbuild.json
 substitutions:
   _NODE10: node:10.24.1-slim
+  _CLOUD_SDK_VERSION: 413.0.0
 
 availableSecrets:
   secretManager:
@@ -47,8 +48,7 @@ steps:
       - run
       - test:e2e
 
-artifacts:
-  objects:
-    location: "gs://ravelinjs-integration-tests/$BUILD_ID"
-    paths:
-      - "/workspace/cipher.txt"
+  - id: upload_cipher
+    name: gcr.io/google.com/cloudsdktool/cloud-sdk:$_CLOUD_SDK_VERSION
+    entrypoint: gsutil
+    args: ["cp", "/workspace/cipher.txt", "gs://ravelinjs-integration-tests/$BUILD_ID"]


### PR DESCRIPTION
We've been seeing the RavelinJS integration test fail with an error like the following:

> Artifacts will be uploaded to gs://ravelinjs-integration-tests using gsutil cp
> ...
> AccessDeniedException: 403 ci-ravelinjs@ravelin-builds.iam.gserviceaccount.com does not have storage.buckets.get access to the Google Cloud Storage bucket.

For an example, see [here](https://console.cloud.google.com/cloud-build/builds;region=global/77bee5f6-4488-48ee-9373-7e7a0c248ff5?project=ravelin-builds).

This commit changes the CI pipeline to manually upload the artefacts into GCS.

See [here](https://github.com/unravelin/terraform/pull/2956) for further monologous discussion.