### PR TITLE
ci: Upload the cipher file correctly

### DIFF
--- a/.cloudbuild/e2e.yaml
+++ b/.cloudbuild/e2e.yaml
@@ -51,4 +51,4 @@ steps:
   - id: upload_cipher
     name: gcr.io/google.com/cloudsdktool/cloud-sdk:$_CLOUD_SDK_VERSION
     entrypoint: gsutil
-    args: ["cp", "/workspace/cipher.txt", "gs://ravelinjs-integration-tests/$BUILD_ID"]
+    args: ["cp", "/workspace/cipher.txt", "gs://ravelinjs-integration-tests/$BUILD_ID/cipher.txt"]


### PR DESCRIPTION
It was writing the file to the UUID, not into a "folder" prefixed with the UUID.