### PR TITLE
ci: Replace all special characters from tunnel identifier.

### DIFF
--- a/test/wdio.conf.mjs
+++ b/test/wdio.conf.mjs
@@ -11,7 +11,7 @@ import { GitHubService, build, browserstackPublicURL, browserstackPrivateURL } f
  */
 
 const buildName = await build();
-const localIdentifier = buildName.replace(/[^a-b0-9_]+/i, '_');
+const localIdentifier = buildName.replace(/[^a-b0-9_]+/gi, '_');
 
 const port = 9998;
 const user = process.env.BROWSERSTACK_USERNAME;


### PR DESCRIPTION
e2e tests are failing because there's still special characters in the name. e.g. "e2e/v1-a06b2c8-f764efed-2230-4933-83d4-6e80148157cb" => "e2e_v1-a06b2c8-f764efed-2230-4933-83d4-6e80148157cb" but we want "e2e_v1_a06b2c8_f764efed_2230_4933_83d4_6e80148157cb"