### PR TITLE
track: Add timezone offset to event metadata

### DIFF
--- a/lib/track.js
+++ b/lib/track.js
@@ -139,7 +139,8 @@ Track.prototype._send = function(type, name, props) {
         ravelinWindowId: that.windowId,
         pageTitle: document.title,
         referrer: document.referrer || undefined,
-        clientEventTimeMilliseconds: Date.now ? Date.now() : +new Date()
+        clientEventTimeMilliseconds:  Date.now ? Date.now() : +new Date(),
+        timezoneOffset: new Date().getTimezoneOffset()
       }
     }]});
   });

--- a/test/track.test.js
+++ b/test/track.test.js
@@ -30,6 +30,7 @@ describe('ravelin.track', function() {
           expect(loadEvent.eventMeta.trackingSource).to.be('browser');
           expect(loadEvent.eventMeta.ravelinDeviceId).to.be(ids.device);
           expect(loadEvent.eventMeta.ravelinSessionId).to.be(ids.session);
+          expect(loadEvent.eventMeta.timezoneOffset).to.be.a('number');
         }).then(done, done);
         return {status: 204};
       });
@@ -49,6 +50,7 @@ describe('ravelin.track', function() {
           expect(loadEvent.eventMeta.trackingSource).to.be('browser');
           expect(loadEvent.eventMeta.ravelinDeviceId).to.be(ids.device);
           expect(loadEvent.eventMeta.ravelinSessionId).to.be(ids.session);
+          expect(loadEvent.eventMeta.timezoneOffset).to.be.a('number');
         }).then(done, done);
         return {status: 204};
       });
@@ -106,6 +108,7 @@ describe('ravelin.track', function() {
             expect(loadEvent.eventMeta.trackingSource).to.be('browser');
             expect(loadEvent.eventMeta.ravelinDeviceId).to.be(ids.device);
             expect(loadEvent.eventMeta.ravelinSessionId).to.be(ids.session);
+            expect(loadEvent.eventMeta.timezoneOffset).to.be.a('number');
           }).then(done, done);
         }
         return {status: 204};
@@ -141,6 +144,7 @@ describe('ravelin.track', function() {
           expect(event.eventMeta.trackingSource).to.be('browser');
           expect(event.eventMeta.ravelinDeviceId).to.be(ids.device);
           expect(event.eventMeta.ravelinSessionId).to.be(ids.session);
+          expect(event.eventMeta.timezoneOffset).to.be.a('number');
           expect(event.eventData).to.eql({
             eventName: 'resize',
             properties: props
@@ -176,6 +180,7 @@ describe('ravelin.track', function() {
           expect(loadEvent.eventMeta.trackingSource).to.be('browser');
           expect(loadEvent.eventMeta.ravelinDeviceId).to.be(ids.device);
           expect(loadEvent.eventMeta.ravelinSessionId).to.be(ids.session);
+          expect(loadEvent.eventMeta.timezoneOffset).to.be.a('number');
         }).then(done, done);
         return {status: 204};
       });
@@ -198,6 +203,7 @@ describe('ravelin.track', function() {
           expect(e.eventMeta.trackingSource).to.be('browser');
           expect(e.eventMeta.ravelinDeviceId).to.be(ids.device);
           expect(e.eventMeta.ravelinSessionId).to.be(ids.session);
+          expect(e.eventMeta.timezoneOffset).to.be.a('number');
         }).then(done, done);
         return {status: 204};
       });
@@ -218,6 +224,7 @@ describe('ravelin.track', function() {
           expect(e.eventMeta.trackingSource).to.be('browser');
           expect(e.eventMeta.ravelinDeviceId).to.be(ids.device);
           expect(e.eventMeta.ravelinSessionId).to.be(ids.session);
+          expect(e.eventMeta.timezoneOffset).to.be.a('number');
         }).then(done, done);
         return {status: 204};
       });
@@ -399,6 +406,7 @@ describe('ravelin.track', function() {
             expect(event.eventMeta.trackingSource).to.be('browser');
             expect(event.eventMeta.ravelinDeviceId).to.be(ids.device);
             expect(event.eventMeta.ravelinSessionId).to.be(ids.session);
+            expect(event.eventMeta.timezoneOffset).to.be.a('number');
             expect(event.eventData).to.eql({
               eventName: 'paste',
               properties: test.props
@@ -435,6 +443,7 @@ describe('ravelin.track', function() {
           expect(event.eventMeta.trackingSource).to.be('browser');
           expect(event.eventMeta.ravelinDeviceId).to.be(ids.device);
           expect(event.eventMeta.ravelinSessionId).to.be(ids.session);
+          expect(event.eventMeta.timezoneOffset).to.be.a('number');
           expect(event.eventData).to.eql({
             eventName: 'paste',
             properties: {
@@ -475,6 +484,7 @@ describe('ravelin.track', function() {
           expect(event.eventMeta.trackingSource).to.be('browser');
           expect(event.eventMeta.ravelinDeviceId).to.be(ids.device);
           expect(event.eventMeta.ravelinSessionId).to.be(ids.session);
+          expect(event.eventMeta.timezoneOffset).to.be.a('number');
           expect(event.eventData).to.eql({
             eventName: 'paste',
             properties: {
@@ -515,6 +525,7 @@ describe('ravelin.track', function() {
           expect(event.eventMeta.trackingSource).to.be('browser');
           expect(event.eventMeta.ravelinDeviceId).to.be(ids.device);
           expect(event.eventMeta.ravelinSessionId).to.be(ids.session);
+          expect(event.eventMeta.timezoneOffset).to.be.a('number');
           expect(event.eventData).to.eql({
             eventName: 'paste',
             properties: {


### PR DESCRIPTION
This updates the library to include the browser's timezone offset in event metadata sent to Ravelin.