### PR TITLE
scripts: Fix publish step

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
   "np": {
     "yarn": false,
     "branch": "v1",
-    "contents": "dist"
+    "contents": "./dist"
   },
   "remarkConfig": {
     "settings": {


### PR DESCRIPTION
When publishing a new release, the publish step fails with an error:

```
npm ERR! 403 403 Forbidden - PUT https://registry.npmjs.org/dist - You do not have permission to publish "dist". Are you logged in as the correct user?
```

This error is discussed in https://github.com/sindresorhus/np/issues/604. This PR applies the suggested workaround.