### PR TITLE
e2e: No need for ngrok tunnel.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "release:integrity": "cd releases/ravelinjs-$npm_package_version; shasum -a 384 *.js | sed s/^/sha384-/ > integrity",
     "release:integrity:verify": "cd releases/ravelinjs-$npm_package_version; sed s/^sha384-// integrity | shasum -c",
     "release:tarball": "cd releases; tar -czf ravelinjs-$npm_package_version.tar.gz ravelinjs-$npm_package_version",
-    "test": "BROWSERS=ie,11 LIMIT=1 LOG_LEVEL=error PARALLEL=4 run-s build test:unit test:integration",
+    "test": "BROWSERS=ie,11 LIMIT=1 LOG_LEVEL=error PARALLEL=4 NGROK_ENABLED=0 run-s build test:unit test:integration",
     "test:e2e": "BROWSERS=chrome,latest LIMIT=1 npm run test:integration -- --spec test/encrypt/encrypt.spec.js",
     "test:unit": "karma start ./test/karma.conf.cjs --single-run",
     "test:unit:watch": "karma start ./test/karma.conf.cjs --auto",

--- a/test/server.js
+++ b/test/server.js
@@ -108,9 +108,10 @@ export function maybeJSON(b) {
  *
  * @param {express.Application} app
  * @param {Number} [port]
+ * @param {Boolean} [withNgrok]
  * @returns {string} The ngrok proxy address to access the server.
  */
-export async function launchProxy(app, port) {
+export async function launchProxy(app, port, withNgrok=true) {
   // Start express listening on a random port.
   var listener;
   const local = await (new Promise((resolve) => {
@@ -121,15 +122,19 @@ export async function launchProxy(app, port) {
   }));
 
   // Spin up an ngrok tunnel pointing to our app.
-  return ngrok.connect({
-    authtoken: process.env.NGROK_AUTH_TOKEN,
-    addr: local.port,
-    onLogEvent: msg => logger.info('ngrok:', msg),
-    onStatusChange: function(status) {
-      // Shut down the express app when ngrok is closed.
-      if (status == 'closed') listener.close();
-    }
-  }).then(url => ({
+  const n = (withNgrok !== false)
+    ? ngrok.connect({
+      authtoken: process.env.NGROK_AUTH_TOKEN,
+      addr: local.port,
+      onLogEvent: msg => logger.info('ngrok:', msg),
+      onStatusChange: function(status) {
+        // Shut down the express app when ngrok is closed.
+        if (status == 'closed') listener.close();
+      }
+    })
+    : Promise.resolve(null);
+
+  return n.then(url => ({
     internal: `http://${local.address}:${local.port}`,
     internalPort: local.port,
     remote: url,

--- a/test/wdio.conf.js
+++ b/test/wdio.conf.js
@@ -398,7 +398,7 @@ class RavelinJSServerLauncher {
   async onPrepare(config, caps) {
     try {
       // Launch our local server and ngrok proxy.
-      const api = await launchProxy(app(), this.port);
+      const api = await launchProxy(app(), this.port, process.env.NGROK_ENABLED !== '0');
       process.env.TEST_INTERNAL = api.internal;
       process.env.TEST_LOCAL = config.baseUrl;
       process.env.TEST_REMOTE = api.remote;


### PR DESCRIPTION
We don't utilise the "remote" URLs in the encrypt.spec.js test, which is what we've been using for end-to-end tests.