### PR TITLE
CI: Switch from gsutil to rclone

### DIFF
--- a/.cloudbuild/ci.yaml
+++ b/.cloudbuild/ci.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://json.schemastore.org/cloudbuild.json
 tags:
   - ravelinjs
+
 substitutions:
   _NODE: node:18-alpine
 

--- a/.cloudbuild/e2e.yaml
+++ b/.cloudbuild/e2e.yaml
@@ -1,8 +1,10 @@
 # yaml-language-server: $schema=https://json.schemastore.org/cloudbuild.json
 tags:
   - ravelinjs
+
 substitutions:
   _NODE: node:18-alpine
+  _RCLONE_IMAGE: europe-docker.pkg.dev/ravelin-builds/container/dockerhub/rclone/rclone:1.61.1
 
 availableSecrets:
   secretManager:
@@ -50,6 +52,6 @@ steps:
       - test:e2e
 
   - id: upload_cipher
-    name: gcr.io/google.com/cloudsdktool/cloud-sdk:latest
-    entrypoint: gsutil
-    args: ["cp", "/workspace/cipher.txt", "gs://ravelinjs-integration-tests/$BUILD_ID/cipher.txt"]
+    name: "$_RCLONE_IMAGE"
+    script: |
+      rclone --config="" copyto /workspace/cipher.txt :gcs: ravelinjs-integration-tests/$BUILD_ID/cipher.txt

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ attribute to any inputs the user types a credit/debit card number into, and a
 `data-rvn-sensitive` to or around any elements you don't want Ravelin to report
 any content from.
 
-→ Read on for more details.
+Read on for more details.
 
 ***
 


### PR DESCRIPTION
The RavelinJS integration test takes around 3 minutes to run. Half of this time is spent uploading the cipher. For example, see [here](https://console.cloud.google.com/cloud-build/builds;region=global/520f0db3-c321-4fdd-9093-3d0269f1e65c;step=3?project=ravelin-builds), where 1m23s was spent uploading the cipher.

The file is around 750B in size. This is a net transfer rate of approximately 9B/s.

In reality, the time is actually spent pulling gcr.io/google.com/cloudsdktool/cloud-sdk:latest. As of the time of writing, this is over 3GB in size.