### PR TITLE
CI: Add an rclone option when uploading to GCS

### DIFF
--- a/.cloudbuild/e2e.yaml
+++ b/.cloudbuild/e2e.yaml
@@ -54,4 +54,4 @@ steps:
   - id: upload_cipher
     name: "$_RCLONE_IMAGE"
     script: |
-      rclone --config="" copyto /workspace/cipher.txt :gcs:ravelinjs-integration-tests/$BUILD_ID/cipher.txt
+      rclone --config="" --gcs-bucket-policy-only copyto /workspace/cipher.txt :gcs:ravelinjs-integration-tests/$BUILD_ID/cipher.txt


### PR DESCRIPTION
> 2024/01/29 13:42:45 ERROR : Attempt 3/3 failed with 1 errors and: googleapi: Error 400: Cannot insert legacy ACL for an object when uniform bucket-level access is enabled. Read more at https://cloud.google.com/storage/docs/uniform-bucket-level-access, invalid

Again, luv runtime errors, me.