### PR TITLE
CI: Try E2_HIGHCPU_32 as the machine type

### DIFF
--- a/.cloudbuild/e2e.yaml
+++ b/.cloudbuild/e2e.yaml
@@ -18,6 +18,7 @@ availableSecrets:
 logsBucket: gs://ravelin-cloudbuild-logs
 options:
   logging: GCS_ONLY
+  machineType: "E2_HIGHCPU_32"
 
 steps:
   - id: npm_install


### PR DESCRIPTION
The tests are faster, but still pretty slow; it's now spending most of its time installing dependencies (~1m). This commit switches to a larger machine type.

There's a risk that this'll lead to scheduling issues, as Cloud Build may now need to wait until a machine of this type is available. There's also a risk that this won't in fact speed things up. (Perhaps the rate-determining step is the downloading of a huge number of things from npm, but it's hard to measure things in CI.)