### PR TITLE
Revert "CI: Try E2_HIGHCPU_32 as the machine type"

### DIFF
--- a/.cloudbuild/e2e.yaml
+++ b/.cloudbuild/e2e.yaml
@@ -18,7 +18,6 @@ availableSecrets:
 logsBucket: gs://ravelin-cloudbuild-logs
 options:
   logging: GCS_ONLY
-  machineType: "E2_HIGHCPU_32"
 
 steps:
   - id: npm_install


### PR DESCRIPTION
Good news: the pipeline is about 30 seconds faster to install its dependencies.

![maim-2024-01-29T15-04-49](https://github.com/unravelin/ravelinjs/assets/10088591/f68a009a-87fa-4241-8118-ae3b98178904)

Bad news: as predicted, the scheduling of a machine of the given type is now the rate-determining step, taking around a minute.

![maim-2024-01-29T15-04-54](https://github.com/unravelin/ravelinjs/assets/10088591/5c42a2e6-0772-48e6-b51f-cbd9a0b67959)

In an ideal world, we'd cache build steps, run CI jobs on a worker pool that we control, etc., but until I make the world an ideal world, unravelin/ravelinjs#468 should be reverted.

The next approach would be to aggressively cut dependencies, to use esbuild, etc., but that's out of scope. I left my previous job in large part to avoid JavaScript.