### PR TITLE
Only raise production level vulnerabilities

### DIFF
--- a/.cloudbuild/ci.yaml
+++ b/.cloudbuild/ci.yaml
@@ -72,5 +72,5 @@ steps:
       "--env", "PROJECT_ID=$PROJECT_ID",
       "--env", "COMMIT_SHA=$COMMIT_SHA",
       "--mount", "type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock,bind-propagation=rprivate",
-      "europe-docker.pkg.dev/$PROJECT_ID/container/gcb2gh",
+      "europe-docker.pkg.dev/$PROJECT_ID/container/gcb2gh:0.0.4",
     ]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,4 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    allow: production


### PR DESCRIPTION
There's a lot of noise from development level vulnerabilities which have all so far been unexploitable. We should focus dependabot alerts on production level vulnerabilities and implement separate dev checks to minimise the noise.