### PR TITLE
Switch to using the official ngrok SDK package

### DIFF
--- a/.cloudbuild/ci.yaml
+++ b/.cloudbuild/ci.yaml
@@ -12,7 +12,7 @@ availableSecrets:
     - versionName: projects/ravelin-builds/secrets/ci-browserstack-username/versions/latest
       env: BROWSERSTACK_USERNAME
     - versionName: projects/ravelin-builds/secrets/ci-ngrok-token/versions/latest
-      env: NGROK_AUTH_TOKEN
+      env: NGROK_AUTHTOKEN
     - versionName: projects/ravelin-builds/secrets/github-token/versions/latest
       env: GITHUB_TOKEN
 
@@ -48,7 +48,7 @@ steps:
     secretEnv:
       - BROWSERSTACK_ACCESS_KEY
       - BROWSERSTACK_USERNAME
-      - NGROK_AUTH_TOKEN
+      - NGROK_AUTHTOKEN
       - GITHUB_TOKEN
     args:
       - run

--- a/.cloudbuild/e2e.yaml
+++ b/.cloudbuild/e2e.yaml
@@ -12,8 +12,6 @@ availableSecrets:
       env: BROWSERSTACK_ACCESS_KEY
     - versionName: projects/ravelin-builds/secrets/ci-browserstack-username/versions/latest
       env: BROWSERSTACK_USERNAME
-    - versionName: projects/ravelin-builds/secrets/ci-ngrok-token/versions/latest
-      env: NGROK_AUTH_TOKEN
 
 logsBucket: gs://ravelin-cloudbuild-logs
 options:
@@ -46,7 +44,6 @@ steps:
     secretEnv:
       - BROWSERSTACK_ACCESS_KEY
       - BROWSERSTACK_USERNAME
-      - NGROK_AUTH_TOKEN
     args:
       - run
       - test:e2e

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,8 +34,7 @@ should find the package.json is already configured to use Node v18.
 
 1. Sign up for an ngrok account: https://dashboard.ngrok.com/signup.
 2. Acquire your authtoken: https://dashboard.ngrok.com/get-started/your-authtoken.
-3. If you have not already done so: `npm install`
-4. From the ravelinjs directory: `node_modules/.bin/ngrok config add-authtoken $TOKEN`.
+3. Authenticate by setting the `NGROK_AUTHTOKEN` envvar (`export NGROK_AUTHTOKEN=x`).
 
 ## 4. Install a JSHint extention in your editor.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.8.1",
       "license": "Apache-2.0",
       "devDependencies": {
+        "@ngrok/ngrok": "1.4.1",
         "@rollup/plugin-commonjs": "20.0.0",
         "@rollup/plugin-node-resolve": "13.3.0",
         "@rollup/plugin-replace": "3.1.0",
@@ -30,7 +31,6 @@
         "karma-expect": "1.1.3",
         "karma-mocha": "2.0.1",
         "mingo": "6.3.4",
-        "ngrok": "5.0.0-beta.2",
         "node-fetch": "3.3.1",
         "np": "7.7.0",
         "npm-check-updates": "16.10.12",
@@ -293,6 +293,235 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@ngrok/ngrok": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok/-/ngrok-1.4.1.tgz",
+      "integrity": "sha512-KZ7/T4UOY3BqJBdweJPeebKW34YzIH+a2y4o7yqTIowoi6dw3sMj140o1Q8FvpPbH5J6lr2TWVCWdgSTYvHNgw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@ngrok/ngrok-android-arm-eabi": "1.4.1",
+        "@ngrok/ngrok-android-arm64": "1.4.1",
+        "@ngrok/ngrok-darwin-arm64": "1.4.1",
+        "@ngrok/ngrok-darwin-universal": "1.4.1",
+        "@ngrok/ngrok-darwin-x64": "1.4.1",
+        "@ngrok/ngrok-freebsd-x64": "1.4.1",
+        "@ngrok/ngrok-linux-arm-gnueabihf": "1.4.1",
+        "@ngrok/ngrok-linux-arm64-gnu": "1.4.1",
+        "@ngrok/ngrok-linux-arm64-musl": "1.4.1",
+        "@ngrok/ngrok-linux-x64-gnu": "1.4.1",
+        "@ngrok/ngrok-linux-x64-musl": "1.4.1",
+        "@ngrok/ngrok-win32-ia32-msvc": "1.4.1",
+        "@ngrok/ngrok-win32-x64-msvc": "1.4.1"
+      }
+    },
+    "node_modules/@ngrok/ngrok-android-arm-eabi": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-android-arm-eabi/-/ngrok-android-arm-eabi-1.4.1.tgz",
+      "integrity": "sha512-KQe59T8PhFg5XvWypcOCIgUakk/A9ipD1UvSgGuLI7pYIiVcx6oyW12RxCJr6cfdO0K5GrbUG6dlEXSmDD4jBg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ngrok/ngrok-android-arm64": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-android-arm64/-/ngrok-android-arm64-1.4.1.tgz",
+      "integrity": "sha512-WPYJenabIArkGmeVhBcIVtgXmLK297pfJCYHP1Tnw220ANEXFdo7EW4dZoP0AA0gxciFHGYnQUMOn1Meo0IQFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ngrok/ngrok-darwin-arm64": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-darwin-arm64/-/ngrok-darwin-arm64-1.4.1.tgz",
+      "integrity": "sha512-hJW+ZDJ0uV7PieZAdZHdzR/WBRctjOkLzFqHTxSuNbmBr9uIg6PGf1dB2lySszK1wyKZL7wvh4GedQ4vSU5lkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ngrok/ngrok-darwin-universal": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-darwin-universal/-/ngrok-darwin-universal-1.4.1.tgz",
+      "integrity": "sha512-rUZKl/vr2cALpT1Ng91h8Jf5OfDtF+zNEC65AFWthPkHJpPQCLvuEC9hyF8XI52Bv45ORRb1YKR3hdhjZ4WGHQ==",
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ngrok/ngrok-darwin-x64": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-darwin-x64/-/ngrok-darwin-x64-1.4.1.tgz",
+      "integrity": "sha512-UKIkRpsGBywAqvwz8L6R8ITz+xxPoZ58LSFhZoMAWm2alGOdA2js1eHZwwVTSz96/tmmSRE/H+r69TvtuL0lXA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ngrok/ngrok-freebsd-x64": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-freebsd-x64/-/ngrok-freebsd-x64-1.4.1.tgz",
+      "integrity": "sha512-v1xXqmu3f4W1PQt+NKlqXgLcpULYCSwStKGRSdgXljg1bRdOnW3ZdjbGzrIdKwQ7OcwZP34KbP13G+hqcTxo5Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ngrok/ngrok-linux-arm-gnueabihf": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-linux-arm-gnueabihf/-/ngrok-linux-arm-gnueabihf-1.4.1.tgz",
+      "integrity": "sha512-yEeiVAGQNUErkSpOI1EZI+X3AkHCGd8yzqfjHamnhEONkwxLcWuTiUfcwFeMVtE9jyLfvQxctldPXXAjvaI/QA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ngrok/ngrok-linux-arm64-gnu": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-linux-arm64-gnu/-/ngrok-linux-arm64-gnu-1.4.1.tgz",
+      "integrity": "sha512-Fb2uju769eO/yOrWdbMvCXNczbXHnqNmN5TCYvqQbPdscFgrsNaJcVr2SmWOfBq+OcLWYbx6mXE1ki5yOZKU9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ngrok/ngrok-linux-arm64-musl": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-linux-arm64-musl/-/ngrok-linux-arm64-musl-1.4.1.tgz",
+      "integrity": "sha512-nMTTZkUnwCzeIVDkoUdNqBKe6ArYXRWGjC4iXinfPOdENkb/tZ/eAjVdg+8bQ5PJgl/n/TbdZKNj//Jz2x8fdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ngrok/ngrok-linux-x64-gnu": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-linux-x64-gnu/-/ngrok-linux-x64-gnu-1.4.1.tgz",
+      "integrity": "sha512-IfDaYd9ZGk7F0szHql5Tr3rlLBlhuKbbNXDVkujGy/njA4/YnckfsZilGEtgnR7aYgHo3NqppfEw+AOmlDytCw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ngrok/ngrok-linux-x64-musl": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-linux-x64-musl/-/ngrok-linux-x64-musl-1.4.1.tgz",
+      "integrity": "sha512-Ze6wb2umg6hfJhxOrFQhiyIZOf9YjSRkefnaQdAaONrIKxiFsu5SIKQbp7MQRnm8wabB9i0OI0Q/TVBsxo/HLw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ngrok/ngrok-win32-ia32-msvc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-win32-ia32-msvc/-/ngrok-win32-ia32-msvc-1.4.1.tgz",
+      "integrity": "sha512-FV3dwGpbh1h2fJ7h+Od8vFRrR9RxqBUAI+ELxQxropDxwYp6rWGKFnfE+JUcT79fEH3OpA0ElULrIDrLgK7bgg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ngrok/ngrok-win32-x64-msvc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-win32-x64-msvc/-/ngrok-win32-x64-msvc-1.4.1.tgz",
+      "integrity": "sha512-Zr1Dyel4M3cA1kjT/N5ftTiCdoPnVv/VbyE6AKKemP9DDFkTlpdvMwSXikm/ypNtCNFEs/+q8CBZPhhaKktl8A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -5098,15 +5327,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/cacheable-lookup": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
-      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10.6.0"
-      }
-    },
     "node_modules/cacheable-request": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.2.tgz",
@@ -8767,13 +8987,6 @@
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
-    "node_modules/hpagent": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-0.1.2.tgz",
-      "integrity": "sha512-ePqFXHtSQWAFXYmj+JtOTHr84iNrII4/QRlAAPPE+zqnKy4xJo7Ie1Y4kC7AdB+LxLxSTTzBMASsEcy0q8YyvQ==",
-      "dev": true,
-      "optional": true
-    },
     "node_modules/htmlparser2": {
       "version": "3.8.3",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
@@ -8877,19 +9090,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/http2-wrapper": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
-      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
-      "dev": true,
-      "dependencies": {
-        "quick-lru": "^5.1.1",
-        "resolve-alpn": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=10.19.0"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -12923,63 +13123,6 @@
       "dev": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/ngrok": {
-      "version": "5.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/ngrok/-/ngrok-5.0.0-beta.2.tgz",
-      "integrity": "sha512-UzsyGiJ4yTTQLCQD11k1DQaMwq2/SsztBg2b34zAqcyjS25qjDpogMKPaCKHwe/APRTHeel3iDXcVctk5CNaCQ==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "extract-zip": "^2.0.1",
-        "got": "^11.8.5",
-        "lodash.clonedeep": "^4.5.0",
-        "uuid": "^7.0.0 || ^8.0.0",
-        "yaml": "^2.2.2"
-      },
-      "bin": {
-        "ngrok": "bin/ngrok"
-      },
-      "engines": {
-        "node": ">=14.2"
-      },
-      "optionalDependencies": {
-        "hpagent": "^0.1.2"
-      }
-    },
-    "node_modules/ngrok/node_modules/got": {
-      "version": "11.8.6",
-      "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
-      "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
-      "dev": true,
-      "dependencies": {
-        "@sindresorhus/is": "^4.0.0",
-        "@szmarczak/http-timer": "^4.0.5",
-        "@types/cacheable-request": "^6.0.1",
-        "@types/responselike": "^1.0.0",
-        "cacheable-lookup": "^5.0.3",
-        "cacheable-request": "^7.0.2",
-        "decompress-response": "^6.0.0",
-        "http2-wrapper": "^1.0.0-beta.5.2",
-        "lowercase-keys": "^2.0.0",
-        "p-cancelable": "^2.0.0",
-        "responselike": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.19.0"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/got?sponsor=1"
-      }
-    },
-    "node_modules/ngrok/node_modules/yaml": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz",
-      "integrity": "sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/nice-try": {
@@ -19593,6 +19736,118 @@
         "chalk": "^4.0.0"
       }
     },
+    "@ngrok/ngrok": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok/-/ngrok-1.4.1.tgz",
+      "integrity": "sha512-KZ7/T4UOY3BqJBdweJPeebKW34YzIH+a2y4o7yqTIowoi6dw3sMj140o1Q8FvpPbH5J6lr2TWVCWdgSTYvHNgw==",
+      "dev": true,
+      "requires": {
+        "@ngrok/ngrok-android-arm-eabi": "1.4.1",
+        "@ngrok/ngrok-android-arm64": "1.4.1",
+        "@ngrok/ngrok-darwin-arm64": "1.4.1",
+        "@ngrok/ngrok-darwin-universal": "1.4.1",
+        "@ngrok/ngrok-darwin-x64": "1.4.1",
+        "@ngrok/ngrok-freebsd-x64": "1.4.1",
+        "@ngrok/ngrok-linux-arm-gnueabihf": "1.4.1",
+        "@ngrok/ngrok-linux-arm64-gnu": "1.4.1",
+        "@ngrok/ngrok-linux-arm64-musl": "1.4.1",
+        "@ngrok/ngrok-linux-x64-gnu": "1.4.1",
+        "@ngrok/ngrok-linux-x64-musl": "1.4.1",
+        "@ngrok/ngrok-win32-ia32-msvc": "1.4.1",
+        "@ngrok/ngrok-win32-x64-msvc": "1.4.1"
+      }
+    },
+    "@ngrok/ngrok-android-arm-eabi": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-android-arm-eabi/-/ngrok-android-arm-eabi-1.4.1.tgz",
+      "integrity": "sha512-KQe59T8PhFg5XvWypcOCIgUakk/A9ipD1UvSgGuLI7pYIiVcx6oyW12RxCJr6cfdO0K5GrbUG6dlEXSmDD4jBg==",
+      "dev": true,
+      "optional": true
+    },
+    "@ngrok/ngrok-android-arm64": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-android-arm64/-/ngrok-android-arm64-1.4.1.tgz",
+      "integrity": "sha512-WPYJenabIArkGmeVhBcIVtgXmLK297pfJCYHP1Tnw220ANEXFdo7EW4dZoP0AA0gxciFHGYnQUMOn1Meo0IQFQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@ngrok/ngrok-darwin-arm64": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-darwin-arm64/-/ngrok-darwin-arm64-1.4.1.tgz",
+      "integrity": "sha512-hJW+ZDJ0uV7PieZAdZHdzR/WBRctjOkLzFqHTxSuNbmBr9uIg6PGf1dB2lySszK1wyKZL7wvh4GedQ4vSU5lkw==",
+      "dev": true,
+      "optional": true
+    },
+    "@ngrok/ngrok-darwin-universal": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-darwin-universal/-/ngrok-darwin-universal-1.4.1.tgz",
+      "integrity": "sha512-rUZKl/vr2cALpT1Ng91h8Jf5OfDtF+zNEC65AFWthPkHJpPQCLvuEC9hyF8XI52Bv45ORRb1YKR3hdhjZ4WGHQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@ngrok/ngrok-darwin-x64": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-darwin-x64/-/ngrok-darwin-x64-1.4.1.tgz",
+      "integrity": "sha512-UKIkRpsGBywAqvwz8L6R8ITz+xxPoZ58LSFhZoMAWm2alGOdA2js1eHZwwVTSz96/tmmSRE/H+r69TvtuL0lXA==",
+      "dev": true,
+      "optional": true
+    },
+    "@ngrok/ngrok-freebsd-x64": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-freebsd-x64/-/ngrok-freebsd-x64-1.4.1.tgz",
+      "integrity": "sha512-v1xXqmu3f4W1PQt+NKlqXgLcpULYCSwStKGRSdgXljg1bRdOnW3ZdjbGzrIdKwQ7OcwZP34KbP13G+hqcTxo5Q==",
+      "dev": true,
+      "optional": true
+    },
+    "@ngrok/ngrok-linux-arm-gnueabihf": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-linux-arm-gnueabihf/-/ngrok-linux-arm-gnueabihf-1.4.1.tgz",
+      "integrity": "sha512-yEeiVAGQNUErkSpOI1EZI+X3AkHCGd8yzqfjHamnhEONkwxLcWuTiUfcwFeMVtE9jyLfvQxctldPXXAjvaI/QA==",
+      "dev": true,
+      "optional": true
+    },
+    "@ngrok/ngrok-linux-arm64-gnu": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-linux-arm64-gnu/-/ngrok-linux-arm64-gnu-1.4.1.tgz",
+      "integrity": "sha512-Fb2uju769eO/yOrWdbMvCXNczbXHnqNmN5TCYvqQbPdscFgrsNaJcVr2SmWOfBq+OcLWYbx6mXE1ki5yOZKU9w==",
+      "dev": true,
+      "optional": true
+    },
+    "@ngrok/ngrok-linux-arm64-musl": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-linux-arm64-musl/-/ngrok-linux-arm64-musl-1.4.1.tgz",
+      "integrity": "sha512-nMTTZkUnwCzeIVDkoUdNqBKe6ArYXRWGjC4iXinfPOdENkb/tZ/eAjVdg+8bQ5PJgl/n/TbdZKNj//Jz2x8fdw==",
+      "dev": true,
+      "optional": true
+    },
+    "@ngrok/ngrok-linux-x64-gnu": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-linux-x64-gnu/-/ngrok-linux-x64-gnu-1.4.1.tgz",
+      "integrity": "sha512-IfDaYd9ZGk7F0szHql5Tr3rlLBlhuKbbNXDVkujGy/njA4/YnckfsZilGEtgnR7aYgHo3NqppfEw+AOmlDytCw==",
+      "dev": true,
+      "optional": true
+    },
+    "@ngrok/ngrok-linux-x64-musl": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-linux-x64-musl/-/ngrok-linux-x64-musl-1.4.1.tgz",
+      "integrity": "sha512-Ze6wb2umg6hfJhxOrFQhiyIZOf9YjSRkefnaQdAaONrIKxiFsu5SIKQbp7MQRnm8wabB9i0OI0Q/TVBsxo/HLw==",
+      "dev": true,
+      "optional": true
+    },
+    "@ngrok/ngrok-win32-ia32-msvc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-win32-ia32-msvc/-/ngrok-win32-ia32-msvc-1.4.1.tgz",
+      "integrity": "sha512-FV3dwGpbh1h2fJ7h+Od8vFRrR9RxqBUAI+ELxQxropDxwYp6rWGKFnfE+JUcT79fEH3OpA0ElULrIDrLgK7bgg==",
+      "dev": true,
+      "optional": true
+    },
+    "@ngrok/ngrok-win32-x64-msvc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@ngrok/ngrok-win32-x64-msvc/-/ngrok-win32-x64-msvc-1.4.1.tgz",
+      "integrity": "sha512-Zr1Dyel4M3cA1kjT/N5ftTiCdoPnVv/VbyE6AKKemP9DDFkTlpdvMwSXikm/ypNtCNFEs/+q8CBZPhhaKktl8A==",
+      "dev": true,
+      "optional": true
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -23188,12 +23443,6 @@
         }
       }
     },
-    "cacheable-lookup": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
-      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
-      "dev": true
-    },
     "cacheable-request": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.2.tgz",
@@ -25922,13 +26171,6 @@
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
-    "hpagent": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-0.1.2.tgz",
-      "integrity": "sha512-ePqFXHtSQWAFXYmj+JtOTHr84iNrII4/QRlAAPPE+zqnKy4xJo7Ie1Y4kC7AdB+LxLxSTTzBMASsEcy0q8YyvQ==",
-      "dev": true,
-      "optional": true
-    },
     "htmlparser2": {
       "version": "3.8.3",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
@@ -26021,16 +26263,6 @@
         "@tootallnate/once": "2",
         "agent-base": "6",
         "debug": "4"
-      }
-    },
-    "http2-wrapper": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
-      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
-      "dev": true,
-      "requires": {
-        "quick-lru": "^5.1.1",
-        "resolve-alpn": "^1.0.0"
       }
     },
     "https-proxy-agent": {
@@ -29001,47 +29233,6 @@
           "version": "0.4.1",
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.4.1.tgz",
           "integrity": "sha512-IwzA/LSfD2vC1/YDYMv/zHP4rDF1usCwllsDpbolT3D4fUepIO7f9K70jjmUewU/LmGUKJcwcVtDCpnKk4BPMw==",
-          "dev": true
-        }
-      }
-    },
-    "ngrok": {
-      "version": "5.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/ngrok/-/ngrok-5.0.0-beta.2.tgz",
-      "integrity": "sha512-UzsyGiJ4yTTQLCQD11k1DQaMwq2/SsztBg2b34zAqcyjS25qjDpogMKPaCKHwe/APRTHeel3iDXcVctk5CNaCQ==",
-      "dev": true,
-      "requires": {
-        "extract-zip": "^2.0.1",
-        "got": "^11.8.5",
-        "hpagent": "^0.1.2",
-        "lodash.clonedeep": "^4.5.0",
-        "uuid": "^7.0.0 || ^8.0.0",
-        "yaml": "^2.2.2"
-      },
-      "dependencies": {
-        "got": {
-          "version": "11.8.6",
-          "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
-          "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
-          "dev": true,
-          "requires": {
-            "@sindresorhus/is": "^4.0.0",
-            "@szmarczak/http-timer": "^4.0.5",
-            "@types/cacheable-request": "^6.0.1",
-            "@types/responselike": "^1.0.0",
-            "cacheable-lookup": "^5.0.3",
-            "cacheable-request": "^7.0.2",
-            "decompress-response": "^6.0.0",
-            "http2-wrapper": "^1.0.0-beta.5.2",
-            "lowercase-keys": "^2.0.0",
-            "p-cancelable": "^2.0.0",
-            "responselike": "^2.0.0"
-          }
-        },
-        "yaml": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz",
-          "integrity": "sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "karma-expect": "1.1.3",
     "karma-mocha": "2.0.1",
     "mingo": "6.3.4",
-    "ngrok": "5.0.0-beta.2",
+    "@ngrok/ngrok": "1.4.1",
     "node-fetch": "3.3.1",
     "np": "7.7.0",
     "npm-check-updates": "16.10.12",

--- a/test/server.mjs
+++ b/test/server.mjs
@@ -11,7 +11,7 @@ import fetch from 'node-fetch';
 import express from 'express';
 import cors from 'cors';
 import serveIndex from 'serve-index';
-import ngrok from 'ngrok';
+import ngrok from '@ngrok/ngrok';
 import mingo from 'mingo';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -124,7 +124,7 @@ export async function launchProxy(app, port, withNgrok=true) {
   // Spin up an ngrok tunnel pointing to our app.
   const n = (withNgrok !== false)
     ? ngrok.connect({
-      authtoken: process.env.NGROK_AUTH_TOKEN,
+      authtoken_from_env: true,
       addr: local.port,
       onLogEvent: msg => logger.info('ngrok:', msg),
       onStatusChange: function(status) {
@@ -134,10 +134,10 @@ export async function launchProxy(app, port, withNgrok=true) {
     })
     : Promise.resolve(null);
 
-  return n.then(url => ({
+  return n.then(listener => ({
     internal: `http://${local.address}:${local.port}`,
     internalPort: local.port,
-    remote: url,
+    remote: listener?.url(),
   }));
 }
 

--- a/test/wdio.conf.mjs
+++ b/test/wdio.conf.mjs
@@ -281,28 +281,10 @@ function buildConfig() {
       },
 
       // iOS
-      // iOS11 currently failing to start with 'COULD NOT START MOBILE BROWSER'.
-      // https://automate.browserstack.com/dashboard/v2/builds/2840b7364373dc5f6f27be58d7bb33374d492668?overallStatus=error
-      // {
-      //   'bstack:options': {
-      //     'osVersion': '11',
-      //     'deviceName': 'iPhone 8',
-      //     'realMobile': 'true',
-      //   },
-      //   'browserName': 'iPhone',
-      // },
       {
         'browserName': 'iPhone',
         'bstack:options': {
-          'osVersion': '12',
-          'deviceName': 'iPhone 8',
-          'realMobile': 'true',
-        },
-      },
-      {
-        'browserName': 'iPhone',
-        'bstack:options': {
-          'osVersion': '13',
+          'osVersion': '11',
           'deviceName': 'iPhone 8',
           'realMobile': 'true',
         },
@@ -312,6 +294,14 @@ function buildConfig() {
         'bstack:options': {
           'osVersion': '14',
           'deviceName': 'iPhone 11',
+          'realMobile': 'true',
+        },
+      },
+      {
+        'browserName': 'iPhone',
+        'bstack:options': {
+          'osVersion': '17',
+          'deviceName': 'iPhone 15',
           'realMobile': 'true',
         },
       },
@@ -370,6 +360,7 @@ function buildConfig() {
           'osVersion': 'Mavericks',
           'seleniumVersion': '3.14.0',
         },
+        'rav:send:skipCrossDomainTest': true,
       },
 
       // Firefox.


### PR DESCRIPTION
The ravelinjs integration tests use [ngrok](https://ngrok.com/) to test cross-origin scenarios. Our version of ngrok is being deprecated soon. This PR upgrades ngrok to use the new official NPM package. 

This PR only touches test-related code and there should be no changes to the library or its functionality. 

![image](https://github.com/user-attachments/assets/0337951f-52c4-462d-93ee-5b8f0ddbac27)

