### PR TITLE
Add InvalidStateError error handling

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -342,7 +342,7 @@ Core.prototype.send = function(method, path, body) {
           reject(r);
         });
       }, function(r) {
-        if (r.isInvalidStateError) {
+        if (r && r.isInvalidStateError) {
           return new c.Promise(function(resolve, reject) {
             reject(r);
           });

--- a/lib/core.js
+++ b/lib/core.js
@@ -318,29 +318,39 @@ Core.prototype.send = function(method, path, body) {
       !sameOrigin(url) && _XDomainRequest) ?
         c._sendXDR(method, url, stringify(body)) :
         c._sendXHR(method, url, stringify(body)
-    ).then(function(r) {
-      r.attempt = attempt;
+    ).then(
+      function(r) {
+        r.attempt = attempt;
 
-      // Resolve/reject based on status.
-      if (r.status == 1223) {
-        r.status = 204; // IE0013 from http://www.enhanceie.com/ie/bugs.asp.
+        // Resolve based on status.
+        if (r.status == 1223) {
+          r.status = 204; // IE0013 from http://www.enhanceie.com/ie/bugs.asp.
+        }
+        if (r.status >= 200 && r.status < 300) {
+          return r;
+        } else if (r.status == 400 && r.text == "") {
+          // Retry empty 400s injected by the BrowserStack tunnel.
+          retry(r);
+        } else if (r.status >= 500) {
+          // Retry errors.
+          retry(r);
+        } else if (!r.status) {
+          // Retry connection errors.
+          retry(r);
+        }
+        return new c.Promise(function(resolve, reject) {
+          reject(r);
+        });
+      }, function(r) {
+        if (r.isInvalidStateError) {
+          return new c.Promise(function(resolve, reject) {
+            reject(r);
+          });
+        } else {
+          retry(r);
+        }
       }
-      if (r.status >= 200 && r.status < 300) {
-        return r;
-      } else if (r.status == 400 && r.text == "") {
-        // Retry empty 400s injected by the BrowserStack tunnel.
-        retry(r);
-      } else if (r.status >= 500) {
-        // Retry errors.
-        retry(r);
-      } else if (!r.status) {
-        // Retry connection errors.
-        retry(r);
-      }
-      return new c.Promise(function(resolve, reject) {
-        reject(r);
-      });
-    });
+    );
   }, 2, this.sendRetryMs)
   .then(undefined, function(r) {
     if (r.attempt) {
@@ -360,17 +370,24 @@ Core.prototype.send = function(method, path, body) {
  * @returns {Promise<CoreResponse>}
  */
 Core.prototype._sendXHR = function(method, url, body) {
-  return new this.Promise(function(resolve) {
+  return new this.Promise(function(resolve, reject) {
     var r = new XMLHttpRequest();
 
-    r.open(method, url);
     r.onreadystatechange = function() {
       if (r.readyState == 4) {
         resolve({status: r.status, text: r.responseText});
       }
     };
-
-    r.send(body);
+    try {
+      r.open(method, url);
+      r.send(body);
+    } catch(e) {
+      if (e instanceof DOMException && e.name === 'InvalidStateError') {
+        e.isInvalidStateError = true;
+      }
+      reject(e);
+      return;
+    }
   });
 };
 

--- a/lib/core.js
+++ b/lib/core.js
@@ -366,7 +366,7 @@ Core.prototype._sendXHR = function(method, url, body) {
     r.open(method, url);
     r.onreadystatechange = function() {
       if (r.readyState == 4) {
-          resolve({status: r.status, text: r.responseText});
+        resolve({status: r.status, text: r.responseText});
       }
     };
 

--- a/lib/core.js
+++ b/lib/core.js
@@ -362,20 +362,20 @@ Core.prototype.send = function(method, path, body) {
 Core.prototype._sendXHR = function(method, url, body) {
   return new this.Promise(function(resolve) {
     var r = new XMLHttpRequest();
+
+    r.open(method, url);
     r.onreadystatechange = function() {
       if (r.readyState == 4) {
-        resolve({status: r.status, text: r.responseText});
+          resolve({status: r.status, text: r.responseText});
       }
     };
 
-    // Send the request.
-    r.open(method, url);
     r.send(body);
   });
 };
 
 /**
- * _sendXDR wraps an XHR in a Promise.
+ * _sendXDR wraps an XDR in a Promise.
  *
  * @param {string} method
  * @param {string} url


### PR DESCRIPTION
### Context
- We received a spate of errors over night.
- They came from the `_sendXHR` function erroring as the request wasn't open yet.
- This happened repeatedly and triggered thousands of retries, which caused rate limiting in the to kick in for a client (600req/min). In total, this error happened 24,000 times in a two hour window.
- [Slack thread](https://ravelin.slack.com/archives/C06U7QCDT3P/p1739225338477979)
- [Error logs](https://cloudlogging.app.goo.gl/sLx8cWY7kUiBmWfWA)
- [Error group](https://console.cloud.google.com/errors/detail/CML00O_w45bVvgE;locations=global;time=P30D?project=ravelin-k8s-live&utm_source=error-reporting-notification&utm_medium=slack&utm_content=new-error&inv=1&invt=AbpRag)
- This hasn't happened before so I don't think it's something we need to be *overly* concerned about.

### Fix (?)
- I've added a try catch block to the `_sendXHR` function which checks for `InvalidStateError` and sets a new attribute if true
- I've added a rejection handler to the `Core.prototype.send` function which checks for this attribute and rejects the promise without retries if it's true and retries otherwise (network errors).
- I *think* this should prevent this happening again.

### MDN docs
- [XMLHttpRequest send](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/send)
- [XMLHttpRequest open](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/open)
- [XMLHttpRequest readystatechange](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/readystatechange_event)