### PR TITLE
Add incognito/private browser detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,6 +482,7 @@ it relies:
 
 * http://bitwiseshiftleft.github.io/sjcl/ (MIT)
 * http://www-cs-students.stanford.edu/~tjw/jsbn/ (BSD)
+* https://github.com/Joe12387/detectIncognito (MIT)
 
 ## Upgrading
 

--- a/lib/track-vendored.js
+++ b/lib/track-vendored.js
@@ -1,0 +1,235 @@
+/*!
+ * This is a vendored version of the detectIncognito library. We've forked the
+ * library (https://github.com/unravelin/detectIncognito) and made a small change
+ * to allow passing in a custom Promise implementation. Supporting a custom
+ * Promise implentation is necessary since ravelinjs offers that config option.
+ * We could remove this once we drop IE support. This script is copied from here:
+ * https://github.com/unravelin/detectIncognito/blob/main/dist/detectIncognito.js#L45-L240
+ *
+ * detectIncognito v1.3.7
+ *
+ * https://github.com/Joe12387/detectIncognito
+ *
+ * MIT License
+ *
+ * Copyright (c) 2021 - 2025 Joe Rutkowski <Joe@dreggle.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Please keep this comment intact in order to properly abide by the MIT License.
+ *
+ **/
+export function detectIncognito(P) {
+  return new P(function (resolve, reject) {
+    var browserName = 'Unknown';
+    function __callback(isPrivate) {
+      resolve({
+        isPrivate: isPrivate,
+        browserName: browserName
+      });
+    }
+    function identifyChromium() {
+      var ua = navigator.userAgent;
+      if (ua.match(/Chrome/)) {
+        if (navigator.brave !== undefined) {
+          return 'Brave';
+        }
+        else if (ua.match(/Edg/)) {
+          return 'Edge';
+        }
+        else if (ua.match(/OPR/)) {
+          return 'Opera';
+        }
+        return 'Chrome';
+      }
+      else {
+        return 'Chromium';
+      }
+    }
+    function assertEvalToString(value) {
+      return value === eval.toString().length;
+    }
+    function feid() {
+      var toFixedEngineID = 0;
+      var neg = parseInt("-1");
+      try {
+        neg.toFixed(neg);
+      }
+      catch (e) {
+        toFixedEngineID = e.message.length;
+      }
+      return toFixedEngineID;
+    }
+    function isSafari() {
+      return feid() === 44;
+    }
+    function isChrome() {
+      return feid() === 51;
+    }
+    function isFirefox() {
+      return feid() === 25;
+    }
+    function isMSIE() {
+      return (navigator.msSaveBlob !== undefined && assertEvalToString(39));
+    }
+    /**
+     * Safari (Safari for iOS & macOS)
+     **/
+    function newSafariTest() {
+      var tmp_name = String(Math.random());
+      try {
+        var db = window.indexedDB.open(tmp_name, 1);
+        db.onupgradeneeded = function (i) {
+          var _a, _b;
+          var res = (_a = i.target) === null || _a === void 0 ? void 0 : _a.result;
+          try {
+            res.createObjectStore('test', {
+              autoIncrement: true
+            }).put(new Blob());
+            __callback(false);
+          }
+          catch (e) {
+            var message = e;
+            if (e instanceof Error) {
+              message = (_b = e.message) !== null && _b !== void 0 ? _b : e;
+            }
+            if (typeof message !== 'string') {
+              __callback(false);
+              return;
+            }
+            var matchesExpectedError = message.includes('BlobURLs are not yet supported');
+            __callback(matchesExpectedError);
+            return;
+          }
+          finally {
+            res.close();
+            window.indexedDB.deleteDatabase(tmp_name);
+          }
+        };
+      }
+      catch (e) {
+        __callback(false);
+      }
+    }
+    function oldSafariTest() {
+      var openDB = window.openDatabase;
+      var storage = window.localStorage;
+      try {
+        openDB(null, null, null, null);
+      }
+      catch (e) {
+        __callback(true);
+        return;
+      }
+      try {
+        storage.setItem('test', '1');
+        storage.removeItem('test');
+      }
+      catch (e) {
+        __callback(true);
+        return;
+      }
+      __callback(false);
+    }
+    function safariPrivateTest() {
+      if (navigator.maxTouchPoints !== undefined) {
+        newSafariTest();
+      }
+      else {
+        oldSafariTest();
+      }
+    }
+    /**
+     * Chrome
+     **/
+    function getQuotaLimit() {
+      var w = window;
+      if (w.performance !== undefined &&
+        w.performance.memory !== undefined &&
+        w.performance.memory.jsHeapSizeLimit !== undefined) {
+        return performance.memory.jsHeapSizeLimit;
+      }
+      return 1073741824;
+    }
+    // >= 76
+    function storageQuotaChromePrivateTest() {
+      navigator.webkitTemporaryStorage.queryUsageAndQuota(function (_, quota) {
+        var quotaInMib = Math.round(quota / (1024 * 1024));
+        var quotaLimitInMib = Math.round(getQuotaLimit() / (1024 * 1024)) * 2;
+        __callback(quotaInMib < quotaLimitInMib);
+      }, function (e) {
+        reject(new Error('detectIncognito somehow failed to query storage quota: ' +
+          e.message));
+      });
+    }
+    // 50 to 75
+    function oldChromePrivateTest() {
+      var fs = window.webkitRequestFileSystem;
+      var success = function () {
+        __callback(false);
+      };
+      var error = function () {
+        __callback(true);
+      };
+      fs(0, 1, success, error);
+    }
+    function chromePrivateTest() {
+      if (self.Promise !== undefined && self.Promise.allSettled !== undefined) {
+        storageQuotaChromePrivateTest();
+      }
+      else {
+        oldChromePrivateTest();
+      }
+    }
+    /**
+     * Firefox
+     **/
+    function firefoxPrivateTest() {
+      __callback(navigator.serviceWorker === undefined);
+    }
+    /**
+     * MSIE
+     **/
+    function msiePrivateTest() {
+      __callback(window.indexedDB === undefined);
+    }
+    function main() {
+      if (isSafari()) {
+        browserName = 'Safari';
+        safariPrivateTest();
+      }
+      else if (isChrome()) {
+        browserName = identifyChromium();
+        chromePrivateTest();
+      }
+      else if (isFirefox()) {
+        browserName = 'Firefox';
+        firefoxPrivateTest();
+      }
+      else if (isMSIE()) {
+        browserName = 'Internet Explorer';
+        msiePrivateTest();
+      }
+      else {
+        reject(new Error('detectIncognito cannot determine the browser'));
+      }
+    }
+    main();
+  });
+}

--- a/lib/track.js
+++ b/lib/track.js
@@ -164,9 +164,13 @@ Track.prototype.incognitoDetected = function() {
   }
 
   try {
-    this._incognitoDetected = detectIncognito(this.core.Promise).then(function(result) {
-      return result.isPrivate;
-    });
+    this._incognitoDetected = detectIncognito(this.core.Promise).then(
+      function(result) {
+        return result.isPrivate;
+      },
+      function() {
+        return false;
+      });
   } catch(e) {
     this._incognitoDetected = this.core.Promise.resolve(false);
   }

--- a/lib/track.js
+++ b/lib/track.js
@@ -1,4 +1,5 @@
-import { uuid } from "./util";
+import { detectIncognito  } from "./track-vendored";
+import { uuid, promiseAll } from "./util";
 
 /**
  * @typedef {object} TrackConfig
@@ -122,7 +123,11 @@ Track.prototype._detach = function() {
  */
 Track.prototype._send = function(type, name, props) {
   var that = this;
-  return this.core.ids().then(function(ids) {
+  var promises = [this.core.ids(), this.incognitoDetected()];
+  return promiseAll(this.core.Promise, promises).then(function(result) {
+    var ids = result[0];
+    var incognitoDetected = result[1];
+
     return that.core.send('POST', '/z', {events: [{
       eventType: type,
       eventData: {
@@ -140,10 +145,32 @@ Track.prototype._send = function(type, name, props) {
         pageTitle: document.title,
         referrer: document.referrer || undefined,
         clientEventTimeMilliseconds:  Date.now ? Date.now() : +new Date(),
+        incognitoDetected: incognitoDetected,
         timezoneOffset: new Date().getTimezoneOffset()
       }
     }]});
   });
+};
+
+/**
+ * incognitoDetected returns a promise-wrapped boolean indicating if the
+ * browser is in private/incognito mode.
+ *
+ * @returns {Promise<boolean>}
+ */
+Track.prototype.incognitoDetected = function() {
+  if (this._incognitoDetected) {
+    return this._incognitoDetected;
+  }
+
+  try {
+    this._incognitoDetected = detectIncognito(this.core.Promise).then(function(result) {
+      return result.isPrivate;
+    });
+  } catch(e) {
+    this._incognitoDetected = this.core.Promise.resolve(false);
+  }
+  return this._incognitoDetected;
 };
 
 /**

--- a/lib/util.js
+++ b/lib/util.js
@@ -129,3 +129,36 @@ export function promiseRetry(P, factory, retries, retryBackoffMs) {
     }
   });
 }
+
+/**
+ * promiseAll is an IE-compatible version of Promise.all(). It aggregates the
+ * results of multiple promises into a single promise.
+ *
+ * TODO: Switch to using Promise.all() when we drop supporting IE.
+ *
+ * @param {PromiseConstructor} P
+ * @param {Promise[]} promises
+ * @returns {Promise}
+ */
+export function promiseAll(P, promises) {
+  return new P(function(resolve, reject) {
+    var finalResult = new Array(promises.length);
+    var resolvedCount = 0;
+
+    function awaitPromise(promise, index) {
+      promise.then(function(result) {
+        finalResult[index] = result;
+        resolvedCount++;
+        if (resolvedCount == promises.length) {
+          resolve(finalResult); // Resolve once all promises are resolved
+        }
+      }, function (err) {
+        reject(err); // Reject if any promise rejects
+      });
+    }
+
+    for (var i = 0; i < promises.length; i++) {
+      awaitPromise(promises[i], i);
+    }
+  });
+}

--- a/test/track.test.js
+++ b/test/track.test.js
@@ -30,6 +30,7 @@ describe('ravelin.track', function() {
           expect(loadEvent.eventMeta.trackingSource).to.be('browser');
           expect(loadEvent.eventMeta.ravelinDeviceId).to.be(ids.device);
           expect(loadEvent.eventMeta.ravelinSessionId).to.be(ids.session);
+          expect(loadEvent.eventMeta.incognitoDetected).to.be(false);
           expect(loadEvent.eventMeta.timezoneOffset).to.be.a('number');
         }).then(done, done);
         return {status: 204};
@@ -50,6 +51,7 @@ describe('ravelin.track', function() {
           expect(loadEvent.eventMeta.trackingSource).to.be('browser');
           expect(loadEvent.eventMeta.ravelinDeviceId).to.be(ids.device);
           expect(loadEvent.eventMeta.ravelinSessionId).to.be(ids.session);
+          expect(loadEvent.eventMeta.incognitoDetected).to.be(false);
           expect(loadEvent.eventMeta.timezoneOffset).to.be.a('number');
         }).then(done, done);
         return {status: 204};
@@ -108,6 +110,7 @@ describe('ravelin.track', function() {
             expect(loadEvent.eventMeta.trackingSource).to.be('browser');
             expect(loadEvent.eventMeta.ravelinDeviceId).to.be(ids.device);
             expect(loadEvent.eventMeta.ravelinSessionId).to.be(ids.session);
+            expect(loadEvent.eventMeta.incognitoDetected).to.be(false);
             expect(loadEvent.eventMeta.timezoneOffset).to.be.a('number');
           }).then(done, done);
         }
@@ -144,6 +147,7 @@ describe('ravelin.track', function() {
           expect(event.eventMeta.trackingSource).to.be('browser');
           expect(event.eventMeta.ravelinDeviceId).to.be(ids.device);
           expect(event.eventMeta.ravelinSessionId).to.be(ids.session);
+          expect(event.eventMeta.incognitoDetected).to.be(false);
           expect(event.eventMeta.timezoneOffset).to.be.a('number');
           expect(event.eventData).to.eql({
             eventName: 'resize',
@@ -180,6 +184,7 @@ describe('ravelin.track', function() {
           expect(loadEvent.eventMeta.trackingSource).to.be('browser');
           expect(loadEvent.eventMeta.ravelinDeviceId).to.be(ids.device);
           expect(loadEvent.eventMeta.ravelinSessionId).to.be(ids.session);
+          expect(loadEvent.eventMeta.incognitoDetected).to.be(false);
           expect(loadEvent.eventMeta.timezoneOffset).to.be.a('number');
         }).then(done, done);
         return {status: 204};
@@ -224,6 +229,7 @@ describe('ravelin.track', function() {
           expect(e.eventMeta.trackingSource).to.be('browser');
           expect(e.eventMeta.ravelinDeviceId).to.be(ids.device);
           expect(e.eventMeta.ravelinSessionId).to.be(ids.session);
+          expect(e.eventMeta.incognitoDetected).to.be(false);
           expect(e.eventMeta.timezoneOffset).to.be.a('number');
         }).then(done, done);
         return {status: 204};
@@ -406,6 +412,7 @@ describe('ravelin.track', function() {
             expect(event.eventMeta.trackingSource).to.be('browser');
             expect(event.eventMeta.ravelinDeviceId).to.be(ids.device);
             expect(event.eventMeta.ravelinSessionId).to.be(ids.session);
+            expect(event.eventMeta.incognitoDetected).to.be(false);
             expect(event.eventMeta.timezoneOffset).to.be.a('number');
             expect(event.eventData).to.eql({
               eventName: 'paste',
@@ -443,6 +450,7 @@ describe('ravelin.track', function() {
           expect(event.eventMeta.trackingSource).to.be('browser');
           expect(event.eventMeta.ravelinDeviceId).to.be(ids.device);
           expect(event.eventMeta.ravelinSessionId).to.be(ids.session);
+          expect(event.eventMeta.incognitoDetected).to.be(false);
           expect(event.eventMeta.timezoneOffset).to.be.a('number');
           expect(event.eventData).to.eql({
             eventName: 'paste',
@@ -484,6 +492,7 @@ describe('ravelin.track', function() {
           expect(event.eventMeta.trackingSource).to.be('browser');
           expect(event.eventMeta.ravelinDeviceId).to.be(ids.device);
           expect(event.eventMeta.ravelinSessionId).to.be(ids.session);
+          expect(event.eventMeta.incognitoDetected).to.be(false);
           expect(event.eventMeta.timezoneOffset).to.be.a('number');
           expect(event.eventData).to.eql({
             eventName: 'paste',
@@ -525,6 +534,7 @@ describe('ravelin.track', function() {
           expect(event.eventMeta.trackingSource).to.be('browser');
           expect(event.eventMeta.ravelinDeviceId).to.be(ids.device);
           expect(event.eventMeta.ravelinSessionId).to.be(ids.session);
+          expect(event.eventMeta.incognitoDetected).to.be(false);
           expect(event.eventMeta.timezoneOffset).to.be.a('number');
           expect(event.eventData).to.eql({
             eventName: 'paste',

--- a/test/track.test.js
+++ b/test/track.test.js
@@ -30,7 +30,7 @@ describe('ravelin.track', function() {
           expect(loadEvent.eventMeta.trackingSource).to.be('browser');
           expect(loadEvent.eventMeta.ravelinDeviceId).to.be(ids.device);
           expect(loadEvent.eventMeta.ravelinSessionId).to.be(ids.session);
-          expect(loadEvent.eventMeta.incognitoDetected).to.be(false);
+          expect(loadEvent.eventMeta.incognitoDetected).to.be.a('boolean');
           expect(loadEvent.eventMeta.timezoneOffset).to.be.a('number');
         }).then(done, done);
         return {status: 204};
@@ -51,7 +51,7 @@ describe('ravelin.track', function() {
           expect(loadEvent.eventMeta.trackingSource).to.be('browser');
           expect(loadEvent.eventMeta.ravelinDeviceId).to.be(ids.device);
           expect(loadEvent.eventMeta.ravelinSessionId).to.be(ids.session);
-          expect(loadEvent.eventMeta.incognitoDetected).to.be(false);
+          expect(loadEvent.eventMeta.incognitoDetected).to.be.a('boolean');
           expect(loadEvent.eventMeta.timezoneOffset).to.be.a('number');
         }).then(done, done);
         return {status: 204};
@@ -110,7 +110,7 @@ describe('ravelin.track', function() {
             expect(loadEvent.eventMeta.trackingSource).to.be('browser');
             expect(loadEvent.eventMeta.ravelinDeviceId).to.be(ids.device);
             expect(loadEvent.eventMeta.ravelinSessionId).to.be(ids.session);
-            expect(loadEvent.eventMeta.incognitoDetected).to.be(false);
+            expect(loadEvent.eventMeta.incognitoDetected).to.be.a('boolean');
             expect(loadEvent.eventMeta.timezoneOffset).to.be.a('number');
           }).then(done, done);
         }
@@ -147,7 +147,7 @@ describe('ravelin.track', function() {
           expect(event.eventMeta.trackingSource).to.be('browser');
           expect(event.eventMeta.ravelinDeviceId).to.be(ids.device);
           expect(event.eventMeta.ravelinSessionId).to.be(ids.session);
-          expect(event.eventMeta.incognitoDetected).to.be(false);
+          expect(event.eventMeta.incognitoDetected).to.be.a('boolean');
           expect(event.eventMeta.timezoneOffset).to.be.a('number');
           expect(event.eventData).to.eql({
             eventName: 'resize',
@@ -184,7 +184,7 @@ describe('ravelin.track', function() {
           expect(loadEvent.eventMeta.trackingSource).to.be('browser');
           expect(loadEvent.eventMeta.ravelinDeviceId).to.be(ids.device);
           expect(loadEvent.eventMeta.ravelinSessionId).to.be(ids.session);
-          expect(loadEvent.eventMeta.incognitoDetected).to.be(false);
+          expect(loadEvent.eventMeta.incognitoDetected).to.be.a('boolean');
           expect(loadEvent.eventMeta.timezoneOffset).to.be.a('number');
         }).then(done, done);
         return {status: 204};
@@ -229,7 +229,7 @@ describe('ravelin.track', function() {
           expect(e.eventMeta.trackingSource).to.be('browser');
           expect(e.eventMeta.ravelinDeviceId).to.be(ids.device);
           expect(e.eventMeta.ravelinSessionId).to.be(ids.session);
-          expect(e.eventMeta.incognitoDetected).to.be(false);
+          expect(e.eventMeta.incognitoDetected).to.be.a('boolean');
           expect(e.eventMeta.timezoneOffset).to.be.a('number');
         }).then(done, done);
         return {status: 204};
@@ -412,7 +412,7 @@ describe('ravelin.track', function() {
             expect(event.eventMeta.trackingSource).to.be('browser');
             expect(event.eventMeta.ravelinDeviceId).to.be(ids.device);
             expect(event.eventMeta.ravelinSessionId).to.be(ids.session);
-            expect(event.eventMeta.incognitoDetected).to.be(false);
+            expect(event.eventMeta.incognitoDetected).to.be.a('boolean');
             expect(event.eventMeta.timezoneOffset).to.be.a('number');
             expect(event.eventData).to.eql({
               eventName: 'paste',
@@ -450,7 +450,7 @@ describe('ravelin.track', function() {
           expect(event.eventMeta.trackingSource).to.be('browser');
           expect(event.eventMeta.ravelinDeviceId).to.be(ids.device);
           expect(event.eventMeta.ravelinSessionId).to.be(ids.session);
-          expect(event.eventMeta.incognitoDetected).to.be(false);
+          expect(event.eventMeta.incognitoDetected).to.be.a('boolean');
           expect(event.eventMeta.timezoneOffset).to.be.a('number');
           expect(event.eventData).to.eql({
             eventName: 'paste',
@@ -492,7 +492,7 @@ describe('ravelin.track', function() {
           expect(event.eventMeta.trackingSource).to.be('browser');
           expect(event.eventMeta.ravelinDeviceId).to.be(ids.device);
           expect(event.eventMeta.ravelinSessionId).to.be(ids.session);
-          expect(event.eventMeta.incognitoDetected).to.be(false);
+          expect(event.eventMeta.incognitoDetected).to.be.a('boolean');
           expect(event.eventMeta.timezoneOffset).to.be.a('number');
           expect(event.eventData).to.eql({
             eventName: 'paste',
@@ -534,7 +534,7 @@ describe('ravelin.track', function() {
           expect(event.eventMeta.trackingSource).to.be('browser');
           expect(event.eventMeta.ravelinDeviceId).to.be(ids.device);
           expect(event.eventMeta.ravelinSessionId).to.be(ids.session);
-          expect(event.eventMeta.incognitoDetected).to.be(false);
+          expect(event.eventMeta.incognitoDetected).to.be.a('boolean');
           expect(event.eventMeta.timezoneOffset).to.be.a('number');
           expect(event.eventData).to.eql({
             eventName: 'paste',


### PR DESCRIPTION
This PR adds support for tracking if a browser is in incognito/private mode. It uses the [detectIncognito](https://github.com/Joe12387/detectIncognito) library, which (as it stands) does a pretty good job at identifying incognito mode in all main browsers.

This change only impacts the track module. Track events sent to Ravelin will include a new `incognitoDetected` boolean field in the event metadata.