### PR TITLE
Allow customising SameSite attribute in cookies

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,13 @@ var rav = new Ravelin({
      */
     // cookieDomain: 'store.com',
     /**
+     * @prop {string} [cookieSameSite] The SameSite attribute to control how
+     * cookies are sent in cross-site requests. If not provided, "None;Secure"
+     * will be used by default for HTTPS connections. This is to support clients
+     * who process card payments in iframes or WebViews.
+     */
+    // cookieSameSite: 'None;Secure',
+    /**
      * @prop {PromiseConstructor} [Promise] An injectable Promise implementation
      * to use. If not provided, defaults to window.Promise or a polyfill if the
      * +promise component is included. Ravelin.Promise contains the default.

--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -3,9 +3,10 @@
  * @class
  * @param {object} cfg The cookiejar configuration.
  * @param {string} [cfg.domain] The domain on which to store cookies.
+ * @param {string} [cfg.sameSite] The SameSite attribute to control how cookies are sent in cross-site requests.
  */
 export function CookieJar(cfg) {
-  this.domain = cfg.domain;
+  this.cfg = cfg;
 }
 
 /**
@@ -35,11 +36,13 @@ CookieJar.prototype.get = function(name) {
 CookieJar.prototype.set = function(c) {
   var cook = c.name + "=" + c.value + ";path=" + (c.path || "/") +
     (c.expires ? ";expires=" + c.expires.toUTCString() : "") +
-    (this.domain ? ";domain=" + this.domain : "");
+    (this.cfg.domain ? ";domain=" + this.cfg.domain : "");
 
   if (typeof(this.samesite) === 'undefined') {
     // Determine the correct value for SameSite.
-    if (hasWebKitSameSiteBug(window.navigator.userAgent)) {
+    if (this.cfg.sameSite) {
+      this.samesite = ';SameSite=' + this.cfg.sameSite;
+    } else if (hasWebKitSameSiteBug(window.navigator.userAgent)) {
       this.samesite = '';
     } else if (window.location.protocol == 'https:') {
       this.samesite = ';SameSite=None;Secure';

--- a/lib/core.js
+++ b/lib/core.js
@@ -14,6 +14,7 @@ import { promiseRetry, bind, uuid } from './util';
  * @prop {string|Promise<string>} [id] An explicit deviceId to use. If the Promise errors or returns an empty value, Ravelin's own deviceId tracking kicks in.
  * @prop {string} [cookie=ravelinDeviceId] The name of the cookie that the deviceId is kept in.
  * @prop {string} [cookieDomain] The domain on which to set cookies.
+ * @prop {string} [cookieSameSite] The SameSite attribute to control how cookies are sent in cross-site requests.
  * @prop {number} [cookieExpiryDays=365] The max lifetime of a deviceId, in days. Values <= 0 makes Ravelin treat the named cookie as read-only.
  * @prop {number} [syncMs=2000] The sync timeout frequency.
  * @prop {number} [sendRetryMs=150] The send retry backoff time.
@@ -38,7 +39,8 @@ export function Core(cfg) {
   this.sessionCookie = cfg.sessionCookie || 'ravelinSessionId';
   this.cookieExpiryDays = cfg.cookieExpiryDays || 365;
   this.cookies = new CookieJar({
-    domain: cfg.cookieDomain
+    domain: cfg.cookieDomain,
+    sameSite: cfg.cookieSameSite
   });
 
   this.prefix = typeof cfg.prefix === 'string' ? cfg.prefix : 'rjs-';

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -396,6 +396,15 @@ describe('ravelin.core', function() {
       });
     });
 
+    it('respects explicit SameSite attribute', function() {
+      // JavaScript cannot directly read the SameSite attribute of a stored
+      // cookie, so this config option can't be tested easily. At least we can
+      // check that the config is passed through to the cookie jar.
+      var cfg = isolate({ cookieSameSite: 'Strict;Secure' });
+      var r = new Ravelin(cfg);
+      expect(r.core.cookies.cfg.sameSite).to.be('Strict;Secure');
+    });
+
     $([
       {key: 'publishable_key_test_123', api: '', expApi: 'https://live.ravelin.click'},
       {key: 'publishable_key_test_123', expApi: 'https://live.ravelin.click'},


### PR DESCRIPTION
This PR adds a new `cookieSameSite` config option to allow customising the cookies' `SameSite` attribute. This can be used to control how cookies are sent in cross-site requests. 

If not provided, the default behaviour will continue to use `SameSite=None;Secure` for HTTPS connections. This is to support clients who process card payments in iframes or WebViews.

Example usage:
``` js
new Ravelin({
  key: '...',
  cookieSameSite: 'Strict'
});
```