### PR TITLE
Update browserstack device capabilities

### DIFF
--- a/test/wdio.conf.mjs
+++ b/test/wdio.conf.mjs
@@ -1,8 +1,8 @@
 import path from 'path';
-import { launchProxy, app } from './server.mjs';
 import { fileURLToPath } from 'url';
 import { SevereServiceError } from 'webdriverio';
-import { GitHubService, build, browserstackPublicURL, browserstackPrivateURL } from './ci.mjs';
+import { GitHubService, browserstackPrivateURL, browserstackPublicURL, build } from './ci.mjs';
+import { app, launchProxy } from './server.mjs';
 
 /**
  * The hooks available to a service added to the config.
@@ -273,8 +273,16 @@ function buildConfig() {
       // },
       {
         'bstack:options': {
-          'osVersion': '7.0',
-          'deviceName': 'Samsung Galaxy S8',
+          'osVersion': '9.0',
+          'deviceName': 'Samsung Galaxy S10',
+          'realMobile': 'true',
+        },
+        'browserName': 'Android'
+      },
+      {
+        'bstack:options': {
+          'osVersion': '11.0',
+          'deviceName': 'Google Pixel 5',
           'realMobile': 'true',
         },
         'browserName': 'Android'
@@ -284,8 +292,16 @@ function buildConfig() {
       {
         'browserName': 'iPhone',
         'bstack:options': {
-          'osVersion': '11',
-          'deviceName': 'iPhone 8',
+          'osVersion': '17',
+          'deviceName': 'iPhone 12',
+          'realMobile': 'true',
+        },
+      },
+      {
+        'browserName': 'iPhone',
+        'bstack:options': {
+          'osVersion': '16',
+          'deviceName': 'iPhone SE 2020',
           'realMobile': 'true',
         },
       },
@@ -293,15 +309,7 @@ function buildConfig() {
         'browserName': 'iPhone',
         'bstack:options': {
           'osVersion': '14',
-          'deviceName': 'iPhone 11',
-          'realMobile': 'true',
-        },
-      },
-      {
-        'browserName': 'iPhone',
-        'bstack:options': {
-          'osVersion': '17',
-          'deviceName': 'iPhone 15',
+          'deviceName': 'iPad Air 4',
           'realMobile': 'true',
         },
       },
@@ -336,7 +344,7 @@ function buildConfig() {
       // Safari.
       {
         'browserName': 'Safari',
-        'browserVersion': '13.0',
+        'browserVersion': '13.1',
         'bstack:options': {
           'os': 'OS X',
           'osVersion': 'Catalina',


### PR DESCRIPTION
Some of the devices we were using for the integration tests are no longer supported by browserstack. This updates the capabilities in the config file to more up to date minimums for the v1 branch.