### PR TITLE
Use HTTPS server for unit and integration tests

### DIFF
--- a/.cloudbuild/ci.yaml
+++ b/.cloudbuild/ci.yaml
@@ -37,7 +37,6 @@ steps:
         mkcert -install
         cd ./certs
         mkcert localhost
-        ls -al
 
   - id: install
     waitFor: ["-"]

--- a/.cloudbuild/ci.yaml
+++ b/.cloudbuild/ci.yaml
@@ -28,14 +28,16 @@ steps:
     name: $_NODE
     entrypoint: sh
     env:
-      - CAROOT=./certs
+      - CAROOT=/workspace/certs
     args:
       - '-c'
       - |
-        apk add --no-cache mkcert
+        mkdir ./certs
+        apk add mkcert --no-cache --repository=http://dl-cdn.alpinelinux.org/edge/testing/
         mkcert -install
         cd ./certs
         mkcert localhost
+        ls -al
 
   - id: install
     waitFor: ["-"]
@@ -62,7 +64,7 @@ steps:
       - COMMIT_SHA=$COMMIT_SHA
       - BUILD_ID=$BUILD_ID
       - HEAD_REPO_URL=$_HEAD_REPO_URL
-      - NODE_EXTRA_CA_CERTS=./certs/rootCA.pem
+      - NODE_EXTRA_CA_CERTS=/workspace/certs/rootCA.pem
     secretEnv:
       - BROWSERSTACK_ACCESS_KEY
       - BROWSERSTACK_USERNAME

--- a/.cloudbuild/ci.yaml
+++ b/.cloudbuild/ci.yaml
@@ -23,13 +23,29 @@ options:
     name: projects/ravelin-builds/locations/europe-west1/workerPools/c3-highcpu-8
 
 steps:
+  - id: mkcert
+    waitFor: ["-"]
+    name: $_NODE
+    entrypoint: sh
+    env:
+      - CAROOT=./certs
+    args:
+      - '-c'
+      - |
+        apk add --no-cache mkcert
+        mkcert -install
+        cd ./certs
+        mkcert localhost
+
   - id: install
+    waitFor: ["-"]
     name: $_NODE
     entrypoint: npm
     args:
       - install
 
   - id: build
+    waitFor: ["install"]
     name: $_NODE
     entrypoint: npm
     args:
@@ -37,8 +53,8 @@ steps:
       - build
 
   - id: browserstack
+    waitFor: ["mkcert", "build"]
     name: $_NODE
-    waitFor: ["build"]
     entrypoint: npm
     env:
       - PARALLEL=5
@@ -46,6 +62,7 @@ steps:
       - COMMIT_SHA=$COMMIT_SHA
       - BUILD_ID=$BUILD_ID
       - HEAD_REPO_URL=$_HEAD_REPO_URL
+      - NODE_EXTRA_CA_CERTS=./certs/rootCA.pem
     secretEnv:
       - BROWSERSTACK_ACCESS_KEY
       - BROWSERSTACK_USERNAME

--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,8 @@ typings/
 
 *.min.js
 *.sri
+*.pem
+certs/
 cipher.txt
 deviceid.txt
 sessionid.txt

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,21 +52,26 @@ CI will run all tests when a commit is pushed to GitHub, essentially:
 
 Locally, you'll be doing the following:
 
-- Edit code in ./lib.
-- Building code into the ./build directory with `npm run build`.
+- Edit code in `./lib`.
+- Building code into the `./build` directory with `npm run build`.
 - After building,
   - Run unit tests locally with `npm run test:unit`.
-  - Authenticate with BrowserStack using `export BROWSERSTACK_USERNAME=x BROWSERSTACK_ACCESS_KEY=y`.
   - Run integration tests with `npm run test:integration`.
-  - Run single integration tests with `npm run test:integration -- --spec example/example.spec.js`.
 - Release code into a versioned release directory with `npm run release`.
 
 There are auto-running commands:
 
 - `npm run build:watch` to auto-build when lib is changed; and
 - `npm run test:unit:watch` to auto-test when build is changed.
+- `npm run watch` will run these two commands together.
 
-**`npm run watch`** will run these two commands together.
+In order to run both unit and integration tests, you'll need to create a local certificate to authenticate HTTPS requests on the test server.
+
+1. Install [mkcert](https://github.com/FiloSottile/mkcert).
+2. Create a `certs` directory at the root of the project and `cd` inside.
+3. Run `mkcert localhost` which will generate two `.pem` files used as the certificate for our test server and browser communication.
+4. Run `mkcert -CAROOT` and note down this path.
+4. While mkcert adds its local Certificate Authority (CA) to your system/browser trust store, Node.js uses its own hardcoded list of trusted CAs and ignores the system store. To solve this, set the `NODE_EXTRA_CA_CERTS` environment variable, either in a `.env` file or in your terminal, to `[CAROOT path]/rootCA.pem`. This allows Node fetch requests to trust our certificate. You must use an absolute path, not a relative path. The result might look like this example: `NODE_EXTRA_CA_CERTS=/Users/username/Library/Application Support/mkcert/rootCA.pem`.
 
 ## 6. Prefer testing in unit tests.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "cors": "2.8.5",
         "dotenv": "17.2.3",
         "eslint": "9.39.2",
-        "express": "4.18.2",
+        "express": "4.22.1",
         "globals": "17.0.0",
         "jquery": "3.7.1",
         "karma": "6.4.4",
@@ -2120,15 +2120,6 @@
         "node": ">= 8.0.0"
       }
     },
-    "node_modules/agentkeepalive/node_modules/depd": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/aggregate-error": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
@@ -2286,8 +2277,9 @@
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
-      "dev": true
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/array-union": {
       "version": "2.1.0",
@@ -2599,23 +2591,24 @@
       "license": "MIT"
     },
     "node_modules/body-parser": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
-      "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
+      "version": "1.20.4",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
+      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
-        "content-type": "~1.0.4",
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
         "debug": "2.6.9",
         "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "on-finished": "2.4.1",
-        "qs": "6.11.0",
-        "raw-body": "2.5.1",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.14.0",
+        "raw-body": "~2.5.3",
         "type-is": "~1.6.18",
-        "unpipe": "1.0.0"
+        "unpipe": "~1.0.0"
       },
       "engines": {
         "node": ">= 0.8",
@@ -2629,15 +2622,6 @@
       "dev": true,
       "dependencies": {
         "ms": "2.0.0"
-      }
-    },
-    "node_modules/body-parser/node_modules/depd": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/body-parser/node_modules/ms": {
@@ -3212,6 +3196,7 @@
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -4083,6 +4068,7 @@
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
       "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "safe-buffer": "5.2.1"
       },
@@ -4108,31 +4094,35 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/content-type": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/cookie-signature": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
-      "dev": true
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/core-util-is": {
       "version": "1.0.2",
@@ -4665,6 +4655,16 @@
       "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
       "dev": true
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -4930,16 +4930,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
-      }
-    },
-    "node_modules/engine.io/node_modules/cookie": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/ent": {
@@ -5395,6 +5385,7 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -5507,45 +5498,50 @@
       }
     },
     "node_modules/express": {
-      "version": "4.18.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
-      "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
+      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.1",
-        "content-disposition": "0.5.4",
+        "body-parser": "~1.20.3",
+        "content-disposition": "~0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.5.0",
-        "cookie-signature": "1.0.6",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
-        "finalhandler": "1.2.0",
-        "fresh": "0.5.2",
-        "http-errors": "2.0.0",
-        "merge-descriptors": "1.0.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
         "methods": "~1.1.2",
-        "on-finished": "2.4.1",
+        "on-finished": "~2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.7",
+        "path-to-regexp": "~0.1.12",
         "proxy-addr": "~2.0.7",
-        "qs": "6.11.0",
+        "qs": "~6.14.0",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
-        "send": "0.18.0",
-        "serve-static": "1.15.0",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
         "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
+        "statuses": "~2.0.1",
         "type-is": "~1.6.18",
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
       },
       "engines": {
         "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/express/node_modules/debug": {
@@ -5553,31 +5549,34 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
       }
     },
-    "node_modules/express/node_modules/depd": {
+    "node_modules/express/node_modules/encodeurl": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
     },
     "node_modules/express/node_modules/finalhandler": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
-      "integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
-        "on-finished": "2.4.1",
+        "on-finished": "~2.4.1",
         "parseurl": "~1.3.3",
-        "statuses": "2.0.1",
+        "statuses": "~2.0.2",
         "unpipe": "~1.0.0"
       },
       "engines": {
@@ -5588,13 +5587,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true
-    },
-    "node_modules/express/node_modules/path-to-regexp": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/express/node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -5614,13 +5608,15 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/express/node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -6009,6 +6005,7 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -7015,35 +7012,32 @@
       "dev": true
     },
     "node_modules/http-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "depd": "2.0.0",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "toidentifier": "1.0.1"
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/http-errors/node_modules/depd": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/http-errors/node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -10046,10 +10040,14 @@
       "dev": true
     },
     "node_modules/merge-descriptors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
-      "dev": true
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -10069,8 +10067,9 @@
     "node_modules/methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -13042,10 +13041,14 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
-      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -13780,6 +13783,13 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/pathval": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
@@ -14063,12 +14073,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
+      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.0.4"
+        "side-channel": "^1.1.0"
       },
       "engines": {
         "node": ">=0.6"
@@ -14138,15 +14149,16 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-      "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "unpipe": "1.0.0"
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
       },
       "engines": {
         "node": ">= 0.8"
@@ -15106,24 +15118,25 @@
       "dev": true
     },
     "node_modules/send": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
-      "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
         "depd": "2.0.0",
         "destroy": "1.2.0",
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
-        "fresh": "0.5.2",
-        "http-errors": "2.0.0",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
         "mime": "1.6.0",
         "ms": "2.1.3",
-        "on-finished": "2.4.1",
+        "on-finished": "~2.4.1",
         "range-parser": "~1.2.1",
-        "statuses": "2.0.1"
+        "statuses": "~2.0.2"
       },
       "engines": {
         "node": ">= 0.8.0"
@@ -15134,6 +15147,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -15142,13 +15156,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true
-    },
-    "node_modules/send/node_modules/depd": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/send/node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -15158,6 +15174,7 @@
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "mime": "cli.js"
       },
@@ -15169,13 +15186,15 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/send/node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -15190,18 +15209,29 @@
       }
     },
     "node_modules/serve-static": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
-      "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "parseurl": "~1.3.3",
-        "send": "0.18.0"
+        "send": "~0.19.1"
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/serve-static/node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/set-blocking": {
@@ -15251,14 +15281,76 @@
       "dev": true
     },
     "node_modules/side-channel": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.0",
-        "get-intrinsic": "^1.0.2",
-        "object-inspect": "^1.9.0"
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "cors": "2.8.5",
     "dotenv": "17.2.3",
     "eslint": "9.39.2",
-    "express": "4.18.2",
+    "express": "4.22.1",
     "globals": "17.0.0",
     "jquery": "3.7.1",
     "karma": "6.4.4",

--- a/test-integration/build-bstack-config.mjs
+++ b/test-integration/build-bstack-config.mjs
@@ -18,6 +18,7 @@ export function buildBrowserStackConfig() {
     consoleLogs: 'verbose',
     networkLogs: true,
     parallelsPerPlatform: 1,
+    acceptInsecureCerts: true,
     browserstackLocal: true,
     browserStackLocalOptions: {
       localProxyHost: 'localhost',

--- a/test-integration/build-bstack-config.mjs
+++ b/test-integration/build-bstack-config.mjs
@@ -18,6 +18,7 @@ export function buildBrowserStackConfig() {
     consoleLogs: 'verbose',
     networkLogs: true,
     parallelsPerPlatform: 1,
+    // Allow HTTPS connections with our self-signed cert
     acceptInsecureCerts: true,
     browserstackLocal: true,
     browserStackLocalOptions: {

--- a/test-integration/ngrok.mjs
+++ b/test-integration/ngrok.mjs
@@ -21,7 +21,12 @@ export async function startTunnel(addr, maxRetries = 3) {
 
   for (let i = 0; i < maxRetries; i++) {
     try {
-      const tunnel = await ngrok.forward({ addr, authtoken_from_env: true });
+      const tunnel = await ngrok.forward({
+        addr,
+        authtoken_from_env: true,
+        // Allow secure connections with our self-signed cert
+        verify_upstream_tls: false,
+      });
 
       console.log(`ngrok tunnel established at ${tunnel.url()}`);
 

--- a/test-integration/ngrok.mjs
+++ b/test-integration/ngrok.mjs
@@ -11,17 +11,17 @@ ngrok.consoleLog('WARN');
  * Retries if it fails to start, up to a maximum number of attempts.
  * This is used to test RavelinJS integration with API URLs that are not on the same domain.
  *
- * @param {number} port - The port to expose.
+ * @param {string} addr - The local address to expose.
  * @param {number} [maxRetries=3] - The maximum number of retry attempts.
  * @returns {Promise<ngrok.Listener>} - A promise that resolves to the ngrok listener object.
  * @throws {Error} - Throws an error if the tunnel fails to start after all attempts.
  */
-export async function startTunnel(port, maxRetries = 3) {
+export async function startTunnel(addr, maxRetries = 3) {
   console.log('Starting ngrok');
 
   for (let i = 0; i < maxRetries; i++) {
     try {
-      const tunnel = await ngrok.forward({ addr: port, authtoken_from_env: true });
+      const tunnel = await ngrok.forward({ addr, authtoken_from_env: true });
 
       console.log(`ngrok tunnel established at ${tunnel.url()}`);
 

--- a/test-integration/ngrok.mjs
+++ b/test-integration/ngrok.mjs
@@ -24,7 +24,7 @@ export async function startTunnel(addr, maxRetries = 3) {
       const tunnel = await ngrok.forward({
         addr,
         authtoken_from_env: true,
-        // Allow secure connections with our self-signed cert
+        // Allow HTTPS connections with our self-signed cert
         verify_upstream_tls: false,
       });
 

--- a/test-integration/run-local.mjs
+++ b/test-integration/run-local.mjs
@@ -5,7 +5,7 @@ import { startServer, stopServer } from './server.mjs';
 // Indicate to Selenium to use a local browser
 process.env.LOCAL_BROWSER = 'true';
 // Override BrowserStack config to use the local server
-process.env.LOCAL_URL = 'http://localhost:3000';
+process.env.LOCAL_URL = 'https://localhost:3000';
 
 const testPath = process.argv[2];
 

--- a/test-integration/run-local.mjs
+++ b/test-integration/run-local.mjs
@@ -1,6 +1,6 @@
 import 'dotenv/config';
 import { spawn } from 'child_process';
-import { startServer, stopServer } from './server.mjs';
+import { checkCertsExist, startServer, stopServer } from './server.mjs';
 
 // Indicate to Selenium to use a local browser
 process.env.LOCAL_BROWSER = 'true';
@@ -13,6 +13,8 @@ if (!testPath) {
   console.error('Please provide a test glob pattern as the first argument.');
   process.exit(1);
 }
+
+checkCertsExist();
 
 startServer(async (tunnelUrl) => {
   console.log('Tunnel URL:', tunnelUrl);

--- a/test-integration/run.mjs
+++ b/test-integration/run.mjs
@@ -2,9 +2,11 @@ import 'dotenv/config';
 import { spawn } from 'child_process';
 import { buildBrowserStackConfig } from './build-bstack-config.mjs';
 import { updateCommitStatus } from './ci.mjs';
-import { startServer, stopServer } from './server.mjs';
+import { checkCertsExist, startServer, stopServer } from './server.mjs';
 
 const logs = [];
+
+checkCertsExist();
 
 buildBrowserStackConfig();
 

--- a/test-integration/run.mjs
+++ b/test-integration/run.mjs
@@ -1,3 +1,4 @@
+import 'dotenv/config';
 import { spawn } from 'child_process';
 import { buildBrowserStackConfig } from './build-bstack-config.mjs';
 import { updateCommitStatus } from './ci.mjs';

--- a/test-integration/send/send.spec.mjs
+++ b/test-integration/send/send.spec.mjs
@@ -23,19 +23,19 @@ describe('ravelinjs.core.send', () => {
   });
 
   it('sends to paths', async () => {
-    // http://bs-local.com:3000/send/ -> /z/
+    // https://bs-local.com:3000/send/ -> /z/
     await runTest('/', 'path');
   });
 
   it('sends to samesite URLs', async () => {
-    // http://bs-local.com:3000/send/ -> http://bs-local.com/z/
-    await runTest(process.env.LOCAL_URL || 'http://bs-local.com/', 'samesite');
+    // https://bs-local.com:3000/send/ -> https://bs-local.com/z/
+    await runTest(process.env.LOCAL_URL || 'https://bs-local.com:3000', 'samesite');
   });
 
   it('sends to remote URLs', async () => {
     console.log('Running remote test:', process.env.TUNNEL_URL);
 
-    // http://bs-local.com:3000/send/ -> https://....ngrok-free.app/
+    // https://bs-local.com:3000/send/ -> https://....ngrok-free.app/
     await runTest(process.env.TUNNEL_URL, 'remote');
   });
 

--- a/test-integration/server-cli.mjs
+++ b/test-integration/server-cli.mjs
@@ -1,4 +1,5 @@
 import 'dotenv/config';
-import { startServer } from './server.mjs';
+import { checkCertsExist, startServer } from './server.mjs';
 
+checkCertsExist();
 startServer();

--- a/test-integration/server.mjs
+++ b/test-integration/server.mjs
@@ -188,7 +188,7 @@ function getBasePath(req) {
 export function checkCertsExist() {
   if (!fs.existsSync('./certs/localhost.pem') || !fs.existsSync('./certs/localhost-key.pem')) {
     console.error(
-      'SSL certificates not found. Please generate localhost.pem and localhost-key.pem in the certs directory.'
+      'Certificates not found. Please generate localhost.pem and localhost-key.pem in the certs directory.'
     );
     process.exit(1);
   }

--- a/test-integration/server.mjs
+++ b/test-integration/server.mjs
@@ -185,6 +185,15 @@ function getBasePath(req) {
   return new URL(req.originalUrl, `https://${req.headers.host}`).pathname;
 }
 
+export function checkCertsExist() {
+  if (!fs.existsSync('./certs/localhost.pem') || !fs.existsSync('./certs/localhost-key.pem')) {
+    console.error(
+      'SSL certificates not found. Please generate localhost.pem and localhost-key.pem in the certs directory.'
+    );
+    process.exit(1);
+  }
+}
+
 process.on('SIGTERM', () => {
   console.log('SIGTERM received, stopping server');
   stopServer();

--- a/test-integration/server.mjs
+++ b/test-integration/server.mjs
@@ -1,5 +1,7 @@
 import cors from 'cors';
 import express from 'express';
+import fs from 'fs';
+import https from 'https';
 import mingo from 'mingo';
 import onFinished from 'on-finished';
 import path from 'path';
@@ -87,14 +89,24 @@ export function startServer(done) {
     }
   });
 
+  // Load HTTPS certificate
+  const options = {
+    key: fs.readFileSync('./certs/localhost-key.pem', 'utf8'),
+    cert: fs.readFileSync('./certs/localhost.pem', 'utf8'),
+  };
+
+  // Create HTTPS server
+  server = https.createServer(options, app);
+
   // Start the server and listen for incoming requests
-  server = app.listen(port, async () => {
-    console.log(`Running at http://localhost:${port}`);
+  server.listen(port, async () => {
+    const address = `https://localhost:${port}`;
+    console.log(`Running at ${address}`);
 
     // Start ngrok unless explicitly disabled
     if (process.env.NGROK_ENABLED !== 'false') {
       try {
-        tunnel = await startTunnel(port);
+        tunnel = await startTunnel(address);
       } catch (err) {
         // Exit and throw the error if ngrok fails to start
         await stopServer();
@@ -170,7 +182,7 @@ function maybeJSON(body) {
  * @returns {string}
  */
 function getBasePath(req) {
-  return new URL(req.originalUrl, `http://${req.headers.host}`).pathname;
+  return new URL(req.originalUrl, `https://${req.headers.host}`).pathname;
 }
 
 process.on('SIGTERM', () => {

--- a/test-integration/server.mjs
+++ b/test-integration/server.mjs
@@ -192,6 +192,13 @@ export function checkCertsExist() {
     );
     process.exit(1);
   }
+  const rootCAPath = process.env.NODE_EXTRA_CA_CERTS;
+  if (rootCAPath && !fs.existsSync(rootCAPath)) {
+    console.error(
+      `NODE_EXTRA_CA_CERTS is set to '${rootCAPath}', but the file does not exist.`
+    );
+    process.exit(1);
+  }
 }
 
 process.on('SIGTERM', () => {

--- a/test-integration/utils.mjs
+++ b/test-integration/utils.mjs
@@ -82,7 +82,7 @@ export function getCurrentPlatform() {
 export function buildUrl({ baseUrl, path, queryParams }) {
   // Default to the BrowserStack local URL which will
   // tunnel requests to our local server.
-  const url = new URL(path, baseUrl || process.env.LOCAL_URL || 'http://bs-local.com:3000');
+  const url = new URL(path, baseUrl || process.env.LOCAL_URL || 'https://bs-local.com:3000');
 
   Object.keys(queryParams).forEach((key) => {
     if (queryParams[key] !== undefined) {
@@ -231,7 +231,7 @@ async function getRequestLog(pattern) {
   const url = buildUrl({
     // Use localhost instead of bs-local.com as we are calling
     // from the same machine running the server.
-    baseUrl: 'http://localhost:3000',
+    baseUrl: 'https://localhost:3000',
     path: '/requests',
     queryParams: { q },
   });

--- a/test-unit/karma.conf.js
+++ b/test-unit/karma.conf.js
@@ -1,5 +1,12 @@
 const fs = require('fs');
 
+if (!fs.existsSync('./certs/localhost.pem') || !fs.existsSync('./certs/localhost-key.pem')) {
+  console.error(
+    'SSL certificates not found. Please generate localhost.pem and localhost-key.pem in the certs directory.'
+  );
+  process.exit(1);
+}
+
 module.exports = function (config) {
   config.set({
     // base path that will be used to resolve all patterns (eg. files, exclude)

--- a/test-unit/karma.conf.js
+++ b/test-unit/karma.conf.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 
 if (!fs.existsSync('./certs/localhost.pem') || !fs.existsSync('./certs/localhost-key.pem')) {
   console.error(
-    'SSL certificates not found. Please generate localhost.pem and localhost-key.pem in the certs directory.'
+    'Certificates not found. Please generate localhost.pem and localhost-key.pem in the certs directory.'
   );
   process.exit(1);
 }

--- a/test-unit/karma.conf.js
+++ b/test-unit/karma.conf.js
@@ -1,6 +1,7 @@
+const fs = require('fs');
+
 module.exports = function (config) {
   config.set({
-
     // base path that will be used to resolve all patterns (eg. files, exclude)
     basePath: '.',
 
@@ -28,6 +29,13 @@ module.exports = function (config) {
     // possible values: 'dots', 'progress'
     // available reporters: https://www.npmjs.com/search?q=keywords:karma-reporter
     reporters: ['progress'],
+
+    // use HTTPS server
+    protocol: 'https:',
+    httpsServerOptions: {
+      key: fs.readFileSync('./certs/localhost-key.pem', 'utf8'),
+      cert: fs.readFileSync('./certs/localhost.pem', 'utf8'),
+    },
 
     // web server port
     port: 9876,


### PR DESCRIPTION
- By updating the detectIncognito library from 1.3.7 to 1.6.2 in PR #491, it changed the way Incognito mode was detected in Firefox to use [storage.getDirectory](https://developer.mozilla.org/en-US/docs/Web/API/StorageManager/getDirectory) which is unavailable on non-secure connections. For some reason this manifests as extremely long unit test runs, causing timeouts, rather than an explicit error.
- To fix the problem, this PR changes unit and integration tests to run in a HTTPS environment, using local certificates created with `mkcert`.