### PR TITLE
Don't default cookie expiry val is set to 0

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -34,7 +34,7 @@ export function Core(cfg) {
   this.sendRetryMs = cfg.sendRetryMs || 150;
   this.cookie = cfg.cookie || 'ravelinDeviceId';
   this.sessionCookie = cfg.sessionCookie || 'ravelinSessionId';
-  this.cookieExpiryDays = cfg.cookieExpiryDays || 365;
+  this.cookieExpiryDays = cfg.cookieExpiryDays ?? 365;
   this.cookies = new CookieJar({
     domain: cfg.cookieDomain,
     sameSite: cfg.cookieSameSite

--- a/test-unit/core.spec.js
+++ b/test-unit/core.spec.js
@@ -322,9 +322,19 @@ describe('ravelin.core', function() {
       });
     });
 
-    it('doesnt set a device ID cookie if cookieExpiryDays <= 0', function() {
+    it(`doesn't set a device ID cookie if cookieExpiryDays < 0`, function() {
       var cfg = isolate({
         cookieExpiryDays: -1
+      });
+      var r = new Ravelin(cfg);
+      return r.core.id().then(function() {
+        expect(r.core.cookies.get(cfg.cookie)).to.equal(undefined);
+      });
+    });
+
+    it(`doesn't set a device ID cookie if cookieExpiryDays = 0`, function() {
+      var cfg = isolate({
+        cookieExpiryDays: 0
       });
       var r = new Ravelin(cfg);
       return r.core.id().then(function() {

--- a/test-unit/track.spec.js
+++ b/test-unit/track.spec.js
@@ -61,7 +61,7 @@ describe('ravelin.track', function() {
       r = new Ravelin(isolate({key: key, api: '/', page: {section: 'test'}}));
     });
 
-    it('doesnt send a page-loaded event when initialised with page:false', function(done) {
+    it(`doesn't send a page-loaded event when initialised with page:false`, function(done) {
       var key = this.test.fullTitle();
       var errored = false;
       xhook.before(function(req) {
@@ -74,7 +74,7 @@ describe('ravelin.track', function() {
       setTimeout(function() { if (!errored) done(); }, 200);
     });
 
-    it('doesnt send resize or page-loaded events when initialised with track:false', function(done) {
+    it(`doesn't send resize or page-loaded events when initialised with track:false`, function(done) {
       var key = this.test.fullTitle();
       var errored = false;
       xhook.before(function(req) {


### PR DESCRIPTION
This fixes a bug that @robcrocombe pointed out. The description of the value did not match the result.