### PR TITLE
v2: remove some old code and simplify event listeners

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -261,7 +261,7 @@ export class Core {
     return promiseRetry(
       (retry, attempt) => {
         // Make the request
-        return this._sendXHR(method, url, stringify(body)).then(r => {
+        return this._sendXHR(method, url, JSON.stringify(body)).then(r => {
           r.attempt = attempt;
 
           // Resolve/reject based on status
@@ -358,22 +358,4 @@ function apiFromKey(key: string | undefined): string {
   }
 
   return 'https://' + encodeURIComponent(env) + '.ravelin.click';
-}
-
-/**
- * stringify is JSON.stringify with prototype safety.
- */
-function stringify(obj: any): string {
-  const proto = Array.prototype as any;
-
-  if (proto.toJSON) {
-    // https://stackoverflow.com/questions/710586/json-stringify-array-bizarreness-with-prototype-js
-    const _array_tojson = proto.toJSON;
-    delete proto.toJSON;
-    const str = JSON.stringify(obj);
-    // Restore native extension
-    proto.toJSON = _array_tojson;
-    return str;
-  }
-  return JSON.stringify(obj);
 }

--- a/src/track.ts
+++ b/src/track.ts
@@ -24,8 +24,6 @@ interface Dimensions {
 
 interface Listener {
   target: EventTarget;
-  addFn: string;
-  delFn: string;
   event: string;
   handler: (e: Event) => unknown;
 }
@@ -87,47 +85,34 @@ export class Track {
 
     this._attach({
       target: document,
-      addFn: 'addEventListener',
-      delFn: 'removeEventListener',
       event: 'paste',
       handler: this.core.bind(this.paste, this),
     });
 
     this._attach({
       target: window,
-      addFn: 'addEventListener',
-      delFn: 'removeEventListener',
       event: 'resize',
       handler: debounce(250, this.core.bind(this.resize, this)),
     });
   }
 
   /**
-   * Mirrors target.addEventListener(event, handler) where addFn would be
-   * 'addEventListener' and delFn 'removeEventListener'.
+   * Mirrors target.addEventListener(event, handler) and
+   * stores the listener so we can remove it later.
    */
-  private _attach(e: Listener): unknown {
+  private _attach(e: Listener): void {
     this._listeners.push(e);
-    const fn = e.target[e.addFn];
-    if (fn.call) {
-      return fn.call(e.target, e.event, e.handler);
-    }
-    return fn(e.event, e.handler);
+    e.target.addEventListener(e.event, e.handler);
   }
 
   /**
-   * Removes event listeners that we added.
+   * Removes event listeners that were added.
    */
   public _detach(): void {
     while (this._listeners && this._listeners.length > 0) {
       const e = this._listeners.pop();
       if (e) {
-        const fn = e.target[e.delFn];
-        if (fn.call) {
-          fn.call(e.target, e.event, e.handler);
-        } else {
-          fn(e.event, e.handler);
-        }
+        e.target.removeEventListener(e.event, e.handler);
       }
     }
   }

--- a/src/track.ts
+++ b/src/track.ts
@@ -164,7 +164,7 @@ export class Track {
                 ravelinWindowId: this.windowId,
                 pageTitle: document.title,
                 referrer: document.referrer || undefined,
-                clientEventTimeMilliseconds: Date.now ? Date.now() : +new Date(),
+                clientEventTimeMilliseconds: Date.now(),
                 incognitoDetected: incognitoDetected,
                 suspectedBot: {
                   bot: botDetected.bot,


### PR DESCRIPTION
- Removed `stringify` bug fix wrapper, the [issue mentioned](https://stackoverflow.com/questions/710586) doesn't seem relevant any more. `JSON.stringify()` is reliable now.
- Removed `+new Date()` fallback, `Date.now()` is standard.
- Simplified code that attached event listeners for paste and resize, now that IE's `attachEvent()` is gone.