### PR TITLE
CI: Add NGROK_AUTHTOKEN to the integration test's environment

### DIFF
--- a/.cloudbuild/e2e.yaml
+++ b/.cloudbuild/e2e.yaml
@@ -12,6 +12,8 @@ availableSecrets:
       env: BROWSERSTACK_ACCESS_KEY
     - versionName: projects/ravelin-builds/secrets/ci-browserstack-username/versions/latest
       env: BROWSERSTACK_USERNAME
+    - versionName: projects/ravelin-builds/secrets/ci-ngrok-token/versions/latest
+      env: NGROK_AUTHTOKEN
 
 logsBucket: gs://ravelin-cloudbuild-logs
 options:
@@ -44,6 +46,7 @@ steps:
     secretEnv:
       - BROWSERSTACK_ACCESS_KEY
       - BROWSERSTACK_USERNAME
+      - NGROK_AUTHTOKEN
     script: |
       #! /usr/bin/env sh
       npm run test:integration


### PR DESCRIPTION
See [this discussion](https://ravelin.slack.com/archives/CMVJZHPUG/p1778067226488649).
