### PR TITLE
CI: Reorder the steps in e2e.yaml

### DIFF
--- a/.cloudbuild/e2e.yaml
+++ b/.cloudbuild/e2e.yaml
@@ -22,19 +22,7 @@ options:
     name: projects/ravelin-builds/locations/europe-west1/workerPools/c3-highcpu-8
 
 steps:
-  - id: npm_install
-    name: $_NODE
-    script: |
-      #! /usr/bin/env sh
-      HUSKY=0 npm install
-
-  - id: npm_run_build
-    name: $_NODE
-    script: |
-      #! /usr/bin/env sh
-      npm run build
-
-  - id: create_certificates
+  - id: mkcert
     name: $_NODE
     env:
       - CAROOT=/workspace/certs
@@ -47,7 +35,19 @@ steps:
       cd ./certs
       mkcert localhost
 
-  - id: npm_run_test_integration
+  - id: install
+    name: $_NODE
+    script: |
+      #! /usr/bin/env sh
+      HUSKY=0 npm install
+
+  - id: build
+    name: $_NODE
+    script: |
+      #! /usr/bin/env sh
+      npm run build
+
+  - id: browserstack
     name: $_NODE
     env:
       - HEAD_BRANCH=$BRANCH_NAME


### PR DESCRIPTION
It's still failing. The error is:

> Error: Error in test: Error: ravelin/encrypt: invalid rsaKey

The next step towards mutuality is to order the steps identically; so, this commit does that.
