### PR TITLE
Run BE E2E tests with local headless Chromium instead of BrowserStack

### DIFF
--- a/.cloudbuild/e2e.yaml
+++ b/.cloudbuild/e2e.yaml
@@ -3,17 +3,8 @@ tags:
   - ravelinjs
 
 substitutions:
-  _NODE: node:22.16.0-alpine
+  _NODE: node:22.16.0-bookworm-slim
   _RCLONE_IMAGE: europe-docker.pkg.dev/ravelin-builds/container/dockerhub/rclone/rclone:1.61.1
-
-availableSecrets:
-  secretManager:
-    - versionName: projects/ravelin-builds/secrets/ci-browserstack-token/versions/latest
-      env: BROWSERSTACK_ACCESS_KEY
-    - versionName: projects/ravelin-builds/secrets/ci-browserstack-username/versions/latest
-      env: BROWSERSTACK_USERNAME
-    - versionName: projects/ravelin-builds/secrets/ci-ngrok-token/versions/latest
-      env: NGROK_AUTHTOKEN
 
 logsBucket: gs://ravelin-cloudbuild-logs
 options:
@@ -29,8 +20,12 @@ steps:
     script: |
       #! /usr/bin/env sh
       set -e
+      apt-get update
+      apt-get install -y --no-install-recommends ca-certificates curl libnss3-tools
+      curl -JLO "https://dl.filippo.io/mkcert/latest?for=linux/amd64"
+      chmod +x mkcert-v*-linux-amd64
+      mv mkcert-v*-linux-amd64 /usr/local/bin/mkcert
       mkdir ./certs
-      apk add mkcert --no-cache --repository=http://dl-cdn.alpinelinux.org/edge/testing/
       mkcert -install
       cd ./certs
       mkcert localhost
@@ -47,22 +42,19 @@ steps:
       #! /usr/bin/env sh
       npm run build
 
-  - id: browserstack
+  - id: e2e
     name: $_NODE
     env:
-      - HEAD_BRANCH=$BRANCH_NAME
-      - COMMIT_SHA=$COMMIT_SHA
-      - BUILD_ID=$BUILD_ID
       - E2E_NAME_ON_CARD=$_NAME_ON_CARD
       - E2E_RSA_KEY=$_RSA_KEY
       - E2E_CIPHERTEXT_FILE=/workspace/cipher.txt
       - NODE_EXTRA_CA_CERTS=/workspace/certs/rootCA.pem
-    secretEnv:
-      - BROWSERSTACK_ACCESS_KEY
-      - BROWSERSTACK_USERNAME
-      - NGROK_AUTHTOKEN
+      - CHROME_BIN=/usr/bin/chromium
     script: |
       #! /usr/bin/env sh
+      set -e
+      apt-get update
+      apt-get install -y --no-install-recommends chromium
       npm run test:e2e
 
   - id: upload_cipher

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "test:unit:watch": "karma start ./test-unit/karma.conf.js --auto",
     "test:integration": "node ./test-integration/run.mjs './test-integration/**/*.spec.mjs'",
     "test:integration:local": "node ./test-integration/run-local.mjs './test-integration/**/*.spec.mjs'",
-    "test:e2e": "NGROK_ENABLED=false CHROME_ONLY=true node ./test-integration/run.mjs './test-integration/encrypt/encrypt.spec.mjs'",
+    "test:e2e": "NGROK_ENABLED=false node ./test-integration/run-local.mjs './test-integration/encrypt/encrypt.spec.mjs'",
     "test:import:setup": "cd test-import && npm run setup",
     "test:import": "npm run test:import:setup && mocha './test-import/*.spec.mjs'",
     "test:bstack-sdk": "browserstack-node-sdk mocha",

--- a/test-integration/utils.mjs
+++ b/test-integration/utils.mjs
@@ -22,7 +22,11 @@ export function buildDriver() {
   if (process.env.LOCAL_BROWSER === 'true') {
     // Use local headless chrome browser
     const options = new chrome.Options();
-    options.addArguments('--headless=new');
+    options.addArguments('--headless=new', '--no-sandbox', '--disable-dev-shm-usage', '--disable-gpu');
+
+    if (process.env.CHROME_BIN) {
+      options.setChromeBinaryPath(process.env.CHROME_BIN);
+    }
 
     return new Builder().forBrowser(Browser.CHROME).setChromeOptions(options).build();
   }


### PR DESCRIPTION
## Summary

- Switch the BE E2E Cloud Build job from BrowserStack to local headless Chromium
- Use the existing `run-local.mjs` path for the encrypt integration test, which only needs one browser to produce ciphertext for GCS upload
- Move the E2E build image from Alpine to Debian bookworm-slim and install Chromium in the test step

## Test plan

- [ ] Trigger the E2E Cloud Build job and confirm the encrypt test passes
- [ ] Confirm `cipher.txt` is uploaded to `gs://ravelinjs-integration-tests/$BUILD_ID/cipher.txt`
- [ ] Confirm the job no longer requires BrowserStack or ngrok secrets
- [ ] Run `npm run test:e2e` locally with certs and `E2E_RSA_KEY` set